### PR TITLE
add tensorboard test scores per timestep

### DIFF
--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -237,7 +237,6 @@ class AutoRegressiveLightning(pl.LightningModule):
             opt.load_state_dict(self.opt_state)
 
         if self.hparams["hparams"].use_lr_scheduler:
-
             len_loader = self.hparams["hparams"].len_train_loader // LR_SCHEDULER_PERIOD
             epochs = self.trainer.max_epochs
             lr_scheduler = get_cosine_schedule_with_warmup(
@@ -349,7 +348,6 @@ class AutoRegressiveLightning(pl.LightningModule):
         # for the desired number of ar steps.
 
         for i in range(batch.num_pred_steps):
-
             if not inference:
                 border_state = batch.outputs.tensor[:, i]
 
@@ -545,7 +543,7 @@ class AutoRegressiveLightning(pl.LightningModule):
         # Notify every plotters
         if self.current_epoch % PLOT_PERIOD == 0:
             for plotter in self.valid_plotters:
-                plotter.on_step_end(self)
+                plotter.on_step_end(self, label="Valid")
 
     def on_test_start(self):
         """
@@ -561,12 +559,11 @@ class AutoRegressiveLightning(pl.LightningModule):
         max_pred_step = self.hparams["hparams"].num_pred_steps_val_test - 1
         self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)
         self.psd_plot_metric = MetricPSDK(save_path, pred_step=max_pred_step)
-        self.rmse_metric = MetricRMSE()
-        self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
+        # self.rmse_metric = MetricRMSE()
+        # self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
         self.test_plotters = [
             StateErrorPlot(metrics, save_path=save_path),
             SpatialErrorPlot(),
-            PredictionTimestepPlot(self.hparams["hparams"].num_samples_to_plot),
             PredictionTimestepPlot(
                 num_samples_to_plot=self.hparams["hparams"].num_samples_to_plot,
                 num_features_to_plot=4,
@@ -586,8 +583,8 @@ class AutoRegressiveLightning(pl.LightningModule):
             plotter.update(self, prediction=prediction, target=target)
         self.psd_plot_metric.update(prediction, target, self.original_shape)
         self.rmse_psd_plot_metric.update(prediction, target, self.original_shape)
-        self.rmse_metric.update(prediction, target)
-        self.acc_metric.update(prediction, target)
+        # self.rmse_metric.update(prediction, target)
+        # self.acc_metric.update(prediction, target)
 
     @cached_property
     def interior_2d(self) -> torch.Tensor:
@@ -611,8 +608,8 @@ class AutoRegressiveLightning(pl.LightningModule):
         # and: https://github.com/Lightning-AI/pytorch-lightning/issues/18803
         self.psd_plot_metric.compute()
         self.rmse_psd_plot_metric.compute()
-        self.rmse_metric.compute()
-        self.acc_metric.compute()
+        # self.rmse_metric.compute()
+        # self.acc_metric.compute()
         # Notify plotters that the test epoch end
         for plotter in self.test_plotters:
-            plotter.on_step_end(self)
+            plotter.on_step_end(self, label="Test")


### PR DESCRIPTION
- Add new scalar to tensorboard that show the same scores as the scores cards, but as curves.
- They can be compared between several models
![image](https://github.com/user-attachments/assets/54dcc0c1-67d6-46db-91d3-2b4625f48a71)
