### PR TITLE
Make py4cast pip installable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,6 @@ permissions:
 
 jobs:
   tests:
-    env:
-      PYTHONPATH: '.'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +28,7 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements_lint.txt
         pip install --timeout 1000 pyg-lib==0.4.0 torch-scatter==2.1.2 torch-sparse==0.6.18 torch-cluster==1.6.2 torch-geometric==2.3.1 -f https://data.pyg.org/whl/torch-2.1.2+cpu.html
+        pip install --editable .
 
     - name: Lint
       run: |

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ This should be done by
 export PY4CAST_ROOTDIR="/my/dir/"
 ```
 
-If you plan to use micromamba or conda you should also add `py4cast` to your **PYTHONPATH** by expanding it (Export or change your `PYTHONPATH`). 
-
-
-
 ### At Météo-France
 
 When working at Météo-France, you can use either runai + Docker or Conda/Micromamba to setup a working environment. On the AI Lab cluster we recommend using runai, Conda on our HPC.
@@ -93,9 +89,19 @@ See the [runai repository](https://git.meteo.fr/dsm-labia/monorepo4ai) for insta
 
 ### Install with conda
 
-You can install a conda environment using
+You can install a conda environment, including `py4cast` in editable mode, using
 ```sh
 conda env create --file env_conda.yaml
+```
+
+From an exixting conda environment, you can now install manually `py4cast` in development mode using
+```sh
+conda install conda-build -n py4cast
+conda develop .
+```
+or
+```sh
+pip install --editable .
 ```
 
 
@@ -104,6 +110,11 @@ conda env create --file env_conda.yaml
 Please install the environment using :
 ```sh
 micromamba create -f env.yaml
+```
+
+From an exixting micromamba environment, you can now install manually `py4cast` in editable mode using
+```sh
+pip install --editable .
 ```
 
 

--- a/env_conda.yaml
+++ b/env_conda.yaml
@@ -34,6 +34,7 @@ dependencies:
   - shapely>=2.0.1
   - netCDF4==1.6.5
   - monai==1.3.1
+  - conda-build==24.7.1
   - pip:
      - tensorboard-plugin-profile
      - torch-tb-profiler==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+
+# Build the long description from the README.md file
+with open("README.md", "r") as readme:
+    long_description = readme.read()
+
+# Build the requirements list from the requirements.txt file
+with open('requirements.txt') as requirements:
+    required = requirements.read().splitlines()
+
+# Instal the sources as a lib
+setup(
+    name="py4cast",
+    version="0.1.0",
+    author="PN-IA Météo France",
+    description="Library to train a variety of Neural Network architectures "
+                "on various weather forecasting datasets.",
+    long_description=long_description,
+    packages=find_packages(),
+    python_requires='>=3.10',
+    install_requires=required
+)

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,26 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Build the long description from the README.md file
 with open("README.md", "r") as readme:
     long_description = readme.read()
 
+
 # Build the requirements list from the requirements.txt file
-with open('requirements.txt') as requirements:
+with open("requirements.txt") as requirements:
     required = requirements.read().splitlines()
+
 
 # Instal the sources as a lib
 setup(
     name="py4cast",
-    version="0.1.0",
+    # version="0.1.0", # Should py4cast have a version number ?
     author="PN-IA Météo France",
-    description="Library to train a variety of Neural Network architectures "
-                "on various weather forecasting datasets.",
+    description=(
+        "Library to train a variety of Neural Network architectures "
+        "on various weather forecasting datasets."
+    ),
     long_description=long_description,
     packages=find_packages(),
-    python_requires='>=3.10',
-    install_requires=required
+    python_requires=">=3.10",
+    install_requires=required,
 )


### PR DESCRIPTION
This PR, that will resolve #18, proposes a `setup.py` file that allows to install `py4cast` as a lib and thus make the code naturally avalaible in the `PYTHON_PATH`.

The main README has been updated to document the installation on `py4cast` in development mode.

The CI workflow has also been updated to use the installable version of `py4cast` instead of the `PYTHON_PATH` export process.
