### PR TITLE
fixing metrics behavior in a multiGPU context

### DIFF
--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -454,8 +454,6 @@ class AutoRegressiveLightning(pl.LightningModule):
         l1_loss.prepare(self, self.interior_mask, self.hparams["hparams"].dataset_info)
         metrics = {"mae": l1_loss}
         save_path = self.hparams["hparams"].save_path
-        self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
-
         self.valid_plotters = [
             StateErrorPlot(metrics, prefix="Validation"),
             PredictionTimestepPlot(
@@ -557,11 +555,7 @@ class AutoRegressiveLightning(pl.LightningModule):
             metrics[alias] = loss
 
         save_path = self.hparams["hparams"].save_path
-        max_pred_step = self.hparams["hparams"].num_pred_steps_val_test - 1
-        self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)
-        self.psd_plot_metric = MetricPSDK(save_path, pred_step=max_pred_step)
-        self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
-
+        
         self.test_plotters = [
             StateErrorPlot(metrics, save_path=save_path),
             SpatialErrorPlot(),

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -555,7 +555,7 @@ class AutoRegressiveLightning(pl.LightningModule):
             metrics[alias] = loss
 
         save_path = self.hparams["hparams"].save_path
-        
+
         self.test_plotters = [
             StateErrorPlot(metrics, save_path=save_path),
             SpatialErrorPlot(),

--- a/py4cast/metrics.py
+++ b/py4cast/metrics.py
@@ -118,7 +118,6 @@ class MetricPSDK(Metric):
         Add the PSD of x to the variable sum_psd
         """
         # x should be (Batch, channels, Lon, Lat) to be an argument of power_spectral_density
-
         x = x.permute(0, -1, *range(2, x.dim() - 1), 1)
         channels = x.shape[1]
 


### PR DESCRIPTION
Reccurrent bugs from tochmetrics in multigPU context (see #41 and #5)

See the referrred issues for stacktraces. The errors happen in multiGPU context, with the gather operation, triggering : 

`RuntimeError: No backend type associated with device type cpu`

The issue is that the metrics must be declared in the scope of the lightning module (and not in the "on_val/test_start" functions scope), to be effectively ported and calculated on multiple devices. So, it does not fail on cpu, nor on single-gpu context.

Moving these declarations in the lightninmodule init is needed.



