### PR TITLE
fix for running on ecmwf atos gpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This should be done by
 export PY4CAST_ROOTDIR="/my/dir/"
 ```
 
-On **ECMWF ATOS** you **MUST** export **PY4CAST_ROOTDIR** to make py4cast work, you can use for instance the existing **SCRATCH** env var:
+You **MUST** export **PY4CAST_ROOTDIR** to make py4cast work, you can use for instance the existing **SCRATCH** env var:
 ```bash
 export PY4CAST_ROOTDIR=$SCRATCH/py4cast
 ```

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ This should be done by
 export PY4CAST_ROOTDIR="/my/dir/"
 ```
 
-On **ECMWF ATOS** you **MUST** export **PY4CAST_ROOTDIR** to make py4cast work:
+On **ECMWF ATOS** you **MUST** export **PY4CAST_ROOTDIR** to make py4cast work, you can use for instance the existing **SCRATCH** env var:
 ```bash
 export PY4CAST_ROOTDIR=$SCRATCH/py4cast
 ```
+
+If **PY4CAST_ROOTDIR** is not exported py4cast will default to use **/scratch/shared/py4cast** as its root directory, leading to Exceptions if this directory does not exist or if it is not writable.
 
 ### At Météo-France
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ This should be done by
 export PY4CAST_ROOTDIR="/my/dir/"
 ```
 
+On **ECMWF ATOS** you **MUST** export **PY4CAST_ROOTDIR** to make py4cast work:
+```bash
+export PY4CAST_ROOTDIR=$SCRATCH/py4cast
+```
+
 ### At Météo-France
 
 When working at Météo-France, you can use either runai + Docker or Conda/Micromamba to setup a working environment. On the AI Lab cluster we recommend using runai, Conda on our HPC.
@@ -171,11 +176,6 @@ Once your micromamba environment is setup, you should :
 A very simple training can be launch (on your current node)
 ```sh
 python bin/train.py  --dataset dummy --model halfunet --epochs 2
-```
-
-On **ECMWF ATOS** you **MUST** export the following env var to make py4cast experiment logging work:
-```bash
-export PY4CAST_ROOTDIR=$SCRATCH
 ```
 
 #### Example of script  to launch on gpu

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ A very simple training can be launch (on your current node)
 python bin/train.py  --dataset dummy --model halfunet --epochs 2
 ```
 
+On **ECMWF ATOS** you **MUST** export the following env var to make py4cast experiment logging work:
+```bash
+export PY4CAST_ROOTDIR=$SCRATCH
+```
 
 #### Example of script  to launch on gpu
 

--- a/env.yaml
+++ b/env.yaml
@@ -44,3 +44,7 @@ dependencies:
      - torch-tb-profiler==0.4.1
      - tueplots>=0.0.8   
      - onnxscript==0.1.0.dev20240421
+     - transformers==4.44.2
+     - gif==23.3.0
+     - scikit-image==0.24.0
+

--- a/env_conda.yaml
+++ b/env_conda.yaml
@@ -40,6 +40,6 @@ dependencies:
      - torch-tb-profiler==0.4.1
      - tueplots>=0.0.8   
      - onnxscript==0.1.0.dev20240421
-
-
-     
+     - transformers==4.44.2
+     - gif==23.3.0
+     - scikit-image==0.24.0


### PR DESCRIPTION
* adds missing conda dependencies
* adds documentation for PY4CAST_ROOTDIR

Tested on ECMWF ATOS with
```bash
srun --nodes=1 --qos=ng --gpus=1 --mem=256G --ntasks-per-node=1 --cpus-per-task=32 --time=5:00:00 --pty bash
export PY4CAST_ROOTDIR=$SCRATCH
python bin/train.py --dataset dummy --model unetrpp --epochs 1
```

![image](https://github.com/user-attachments/assets/b19ef31d-0572-42c8-b682-99da3a063d34)

