### PR TITLE
fix np.load with memory mapping

### DIFF
--- a/py4cast/datasets/poesy.py
+++ b/py4cast/datasets/poesy.py
@@ -222,8 +222,8 @@ class Param:
         date : Date of file.
         term : Position of leadtimes in file.
         """
-        data_array = np.memmap(
-            self.filename(date=date), dtype="float32", mode="r", shape=DATA_SHAPE
+        data_array = np.load(
+            self.filename(date=date), mmap_mode="r"
         )
 
         return data_array[

--- a/py4cast/datasets/poesy.py
+++ b/py4cast/datasets/poesy.py
@@ -222,9 +222,7 @@ class Param:
         date : Date of file.
         term : Position of leadtimes in file.
         """
-        data_array = np.load(
-            self.filename(date=date), mmap_mode="r"
-        )
+        data_array = np.load(self.filename(date=date), mmap_mode="r")
 
         return data_array[
             self.grid.subgrid[0] : self.grid.subgrid[1],


### PR DESCRIPTION
The use of np.memmap changes the data type (need to save the npy files to rbf files before using np.memmap). One solution : replace the np.memmap by np.load with memory mapping mode.