### PR TITLE
Makes inference safer against feature type and ordering errors + infe…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,8 @@ jobs:
         export PY4CAST_ROOTDIR=`pwd`
         coverage run -p -m pytest tests/
         coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
+        coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1 --strategy scaled_ar
+        coverage run -p bin/inference.py --model_path /home/runner/work/py4cast/py4cast/logs/camp0/dummy/halfunet/runn_run_0/
         coverage run -p bin/train.py --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage combine
         coverage report  --ignore-errors --fail-under=60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         coverage run -p -m pytest tests/
         coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1 --strategy scaled_ar
-        coverage run -p bin/inference.py --model_path /home/runner/work/py4cast/py4cast/logs/camp0/dummy/halfunet/runn_run_0/
+        coverage run -p bin/inference.py --dataset dummy --model_path /home/runner/work/py4cast/py4cast/logs/camp0/dummy/halfunet/runn_run_0/
         coverage run -p bin/train.py --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage combine
         coverage report  --ignore-errors --fail-under=60

--- a/bin/inference.py
+++ b/bin/inference.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 
 from pytorch_lightning import Trainer
 
@@ -22,6 +23,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Load checkpoint
+    if Path(args.model_path).is_dir():
+        # Find the first checkpoint in the directory and load it
+        for file in Path(args.model_path).iterdir():
+            if file.suffix == ".ckpt":
+                args.model_path = file
+                break
     lightning_module = AutoRegressiveLightning.load_from_checkpoint(args.model_path)
     hparams = lightning_module.hparams["hparams"]
 

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -359,7 +359,7 @@ class AutoRegressiveLightning(pl.LightningModule):
 
             if scale_y:
                 step_diff_std, step_diff_mean = self._step_diffs(
-                    batch.inputs.feature_names
+                    self.output_feature_names
                     if inference
                     else batch.outputs.feature_names,
                     prev_states.device,
@@ -402,10 +402,15 @@ class AutoRegressiveLightning(pl.LightningModule):
         prediction = torch.stack(
             prediction_list, dim=1
         )  # Stacking is done on time step. (B, pred_steps, N_grid, d_f) or (B, pred_steps, N_lat, N_lon, d_f)
-        pred_out = NamedTensor.new_like(
-            prediction, batch.inputs if inference else batch.outputs
-        )
 
+        # In inference mode we use a "trained" module which MUST have the output feature names
+        # and the output dim names attributes set.
+        if inference:
+            pred_out = NamedTensor(
+                prediction, self.output_dim_names, self.output_feature_names
+            )
+        else:
+            pred_out = NamedTensor.new_like(prediction, batch.outputs)
         return pred_out, batch.outputs
 
     def on_train_start(self):
@@ -419,10 +424,19 @@ class AutoRegressiveLightning(pl.LightningModule):
         tb = self.logger.experiment
         tb.add_scalar(f"mean_loss_epoch/{label}", avg_loss, self.current_epoch)
 
-    def training_step(self, batch: ItemBatch) -> torch.Tensor:
+    def training_step(self, batch: ItemBatch, batch_idx: int) -> torch.Tensor:
         """
         Train on single batch
         """
+
+        # we save the feature names at the first batch
+        # to check at inference time if the feature names are the same
+        # also useful to build NamedTensor outputs with same feature and dim names
+        if batch_idx == 0:
+            self.input_feature_names = batch.inputs.feature_names
+            self.output_feature_names = batch.outputs.feature_names
+            self.output_dim_names = batch.outputs.names
+
         prediction, target = self.common_step(batch)
         # Compute loss: mean over unrolled times and batch
         batch_loss = torch.mean(self.loss(prediction, target))
@@ -434,6 +448,35 @@ class AutoRegressiveLightning(pl.LightningModule):
             plotter.update(self, prediction=self.prediction, target=self.target)
 
         return batch_loss
+
+    def on_save_checkpoint(self, checkpoint):
+        """
+        We store our feature and dim names in the checkpoint
+        """
+        checkpoint["input_feature_names"] = self.input_feature_names
+        checkpoint["output_feature_names"] = self.output_feature_names
+        checkpoint["output_dim_names"] = self.output_dim_names
+
+    def on_load_checkpoint(self, checkpoint):
+        """
+        We load our feature and dim names from the checkpoint
+        """
+        self.input_feature_names = checkpoint["input_feature_names"]
+        self.output_feature_names = checkpoint["output_feature_names"]
+        self.output_dim_names = checkpoint["output_dim_names"]
+
+    def predict_step(self, batch: ItemBatch, batch_idx: int) -> torch.Tensor:
+        """
+        Check if the feature names are the same as the one used during training
+        and make a prediction.
+        """
+        if batch_idx == 0:
+            if self.input_feature_names != batch.inputs.feature_names:
+                raise ValueError(
+                    f"Input Feature names mismatch between training and inference. "
+                    f"Training: {self.input_feature_names}, Inference: {batch.inputs.feature_names}"
+                )
+        return self.forward(batch)
 
     def forward(self, x: ItemBatch) -> NamedTensor:
         """


### PR DESCRIPTION
* Make inference.py able to take a dir as model_path, it will load the first available .ckpt (useful for tests)
* lightning module now saves the input, output feature names and dim names during its first batch and includes these attributes in its checkpoint loading/saving
* these feature and dim names are re-used at inference time to check consistency and also name output Tensors with the same dim and features as output provided during training
* Adds an inference test in the CI