### PR TITLE
Fp16 bf16 support + flash attention from flash_attn

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,8 @@ jobs:
       run: |
         export PY4CAST_ROOTDIR=`pwd`
         coverage run -p -m pytest tests/
-        coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
-        coverage run -p bin/train.py --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
-        coverage run -p bin/train.py --model unetrpp --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
+        coverage run -p bin/train.py --precision 32 --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
+        coverage run -p bin/train.py --precision 32 --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
+        coverage run -p bin/train.py --precision 32 --model unetrpp --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage combine
         coverage report  --ignore-errors --fail-under=60

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.1.2-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.1.2-cuda12.1-cudnn8-devel
 
 ARG INJECT_MF_CERT
 
@@ -6,6 +6,8 @@ COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 
 # The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
+# set apt to non interactive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV MY_APT='apt -o "Acquire::https::Verify-Peer=false" -o "Acquire::AllowInsecureRepositories=true" -o "Acquire::AllowDowngradeToInsecureRepositories=true" -o "Acquire::https::Verify-Host=false"'
 
 RUN $MY_APT update && $MY_APT install -y software-properties-common && add-apt-repository ppa:ubuntugis/ppa
@@ -24,6 +26,7 @@ RUN curl -O https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$
 RUN pip install --upgrade pip
 COPY requirements.txt /root/requirements.txt
 RUN set -eux && pip install --default-timeout=100 -r /root/requirements.txt
+RUN pip install flash-attn --no-build-isolation
 
 ARG USERNAME
 ARG GROUPNAME

--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ options:
                         Name of the dataset config file to use
   --infer_steps INFER_STEPS
                         Number of auto-regressive steps/prediction steps during the inference
-
+   --precision PRECISION
+                        floating point precision for the inference (default: 32) 
 ```
 
 A simple example of inference is shown below:

--- a/bin/inference.py
+++ b/bin/inference.py
@@ -19,6 +19,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--infer_steps", type=int, help="Number of inference steps", default=1
     )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        help="floating point precision for the inference",
+        default="32",
+    )
 
     args = parser.parse_args()
 
@@ -31,6 +37,7 @@ if __name__ == "__main__":
                 break
     lightning_module = AutoRegressiveLightning.load_from_checkpoint(args.model_path)
     hparams = lightning_module.hparams["hparams"]
+    lightning_module.hparams["precision"] = args.precision
 
     if args.date is not None:
         config_override = {
@@ -53,6 +60,5 @@ if __name__ == "__main__":
     # Transform in dataloader
     dl_settings = TorchDataloaderSettings(batch_size=1)
     infer_loader = infer_ds.torch_dataloader(dl_settings)
-
     trainer = Trainer(devices="auto")
     preds = trainer.predict(lightning_module, infer_loader)

--- a/bin/train.py
+++ b/bin/train.py
@@ -233,7 +233,7 @@ if torch.cuda.is_available():
     device_name = "cuda"
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
-    # torch.set_float32_matmul_precision("high") # Allows using Tensor Cores on A100s
+    torch.set_float32_matmul_precision("high")  # Allows using Tensor Cores on A100s
     len_loader = len(train_loader) // (torch.cuda.device_count() * nb_nodes)
 else:
     device_name = "cpu"
@@ -269,6 +269,7 @@ hp = ArLightningHyperParam(
     len_train_loader=len_loader,
     save_path=save_path,
     use_lr_scheduler=args.use_lr_scheduler,
+    precision=args.precision,
 )
 
 # Logger & checkpoint callback

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -449,7 +449,10 @@ class Stats:
         return self.stats[shortname]
 
     def to_list(
-        self, aggregate: Literal["mean", "std", "min", "max"], shortnames: List[str]
+        self,
+        aggregate: Literal["mean", "std", "min", "max"],
+        shortnames: List[str],
+        dtype: torch.dtype = torch.float32,
     ) -> list:
         """
         Get a tensor with the stats inside.
@@ -465,7 +468,7 @@ class Stats:
         if len(shortnames) > 0:
             return torch.stack(
                 [self[name][aggregate] for name in shortnames], dim=0
-            ).type(torch.float32)
+            ).type(dtype)
         else:
             return []
 

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -312,15 +312,13 @@ class AutoRegressiveLightning(pl.LightningModule):
         """
         Get the mean and std of the differences between two consecutive states on the desired device.
         """
-        step_diff_std = self.diff_stats.to_list(
-            "std", feature_names, dtype=self.dtype
-        ).to(
+        step_diff_std = self.diff_stats.to_list("std", feature_names).to(
             device,
             non_blocking=True,
         )
-        step_diff_mean = self.diff_stats.to_list(
-            "mean", feature_names, dtype=self.dtype
-        ).to(device, non_blocking=True)
+        step_diff_mean = self.diff_stats.to_list("mean", feature_names).to(
+            device, non_blocking=True
+        )
         return step_diff_std, step_diff_mean
 
     def _strategy_params(self) -> Tuple[bool, bool, int]:

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -451,7 +451,11 @@ class AutoRegressiveLightning(pl.LightningModule):
         prediction = torch.stack(
             prediction_list, dim=1
         )  # Stacking is done on time step. (B, pred_steps, N_grid, d_f) or (B, pred_steps, N_lat, N_lon, d_f)
-        prediction = prediction.type_as(batch.outputs.tensor)
+        if inference:
+            # for inference we assume for now that float32 is used
+            prediction = prediction.type(torch.float32)
+        else:
+            prediction = prediction.type_as(batch.outputs.tensor)
         pred_out = NamedTensor.new_like(
             prediction, batch.inputs if inference else batch.outputs
         )

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -26,6 +26,7 @@ from py4cast.observer import (
     SpatialErrorPlot,
     StateErrorPlot,
 )
+from py4cast.utils import str_to_dtype
 
 # learning rate scheduling period in steps (update every nth step)
 LR_SCHEDULER_PERIOD: int = 10
@@ -117,15 +118,6 @@ class AutoRegressiveLightning(pl.LightningModule):
     """
     Auto-regressive lightning module for predicting meteorological fields.
     """
-
-    str_to_dtype = {
-        "float32": torch.float32,
-        "32": torch.float32,
-        "float64": torch.float64,
-        "float16": torch.float16,
-        "16": torch.float16,
-        "bf16": torch.bfloat16,
-    }
 
     def __init__(self, hparams: ArLightningHyperParam, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -230,7 +222,7 @@ class AutoRegressiveLightning(pl.LightningModule):
         """
         Return the appropriate torch dtype for the desired precision in hparams.
         """
-        return self.str_to_dtype[self.hparams["hparams"].precision]
+        return str_to_dtype[self.hparams["hparams"].precision]
 
     @rank_zero_only
     def inspect_tensors(self):

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -349,6 +349,22 @@ class AutoRegressiveLightning(pl.LightningModule):
         self, batch: ItemBatch, inference: bool = False
     ) -> Tuple[NamedTensor, NamedTensor]:
         """
+        Handling autocast subtelty for mixed precision on GPU and CPU (only bf16 for the later).
+        """
+        if torch.cuda.is_available():
+            with torch.cuda.amp.autocast(dtype=self.dtype):
+                return self._common_step(batch, inference)
+        else:
+            if "bf16" in self.trainer.precision:
+                with torch.cpu.amp.autocast(dtype=self.dtype):
+                    return self._common_step(batch, inference)
+            else:
+                return self._common_step(batch, inference)
+
+    def _common_step(
+        self, batch: ItemBatch, inference: bool = False
+    ) -> Tuple[NamedTensor, NamedTensor]:
+        """
         Two Autoregressive strategies are implemented here for train, val, test and inference:
         - scaled_ar:
             * Boundary forcing with y_true/true_state
@@ -364,93 +380,91 @@ class AutoRegressiveLightning(pl.LightningModule):
 
         In inference mode, we assume batch.outputs is None and we disable output based border forcing.
         """
-        with torch.autocast(device_type="cuda", dtype=self.dtype):
+        force_border, scale_y, num_inter_steps = self._strategy_params()
+        # Right now we postpone that we have a single input/output/forcing
 
-            force_border, scale_y, num_inter_steps = self._strategy_params()
-            # Right now we postpone that we have a single input/output/forcing
+        self.original_shape = None
 
-            self.original_shape = None
+        if len(self.model.input_dims) == 3:
+            # Stack original shape to reshape later
+            self.original_shape = batch.inputs.tensor.shape
+            # Graph model, we flatten the batch spatial dims
+            batch.inputs.flatten_("ngrid", 2, 3)
 
-            if len(self.model.input_dims) == 3:
-                # Stack original shape to reshape later
-                self.original_shape = batch.inputs.tensor.shape
-                # Graph model, we flatten the batch spatial dims
-                batch.inputs.flatten_("ngrid", 2, 3)
+            if not inference:
+                batch.outputs.flatten_("ngrid", 2, 3)
 
-                if not inference:
-                    batch.outputs.flatten_("ngrid", 2, 3)
+            batch.forcing.flatten_("ngrid", 2, 3)
 
-                batch.forcing.flatten_("ngrid", 2, 3)
+        prev_states = batch.inputs.tensor
+        prediction_list = []
 
-            prev_states = batch.inputs.tensor
-            prediction_list = []
+        # Here we do the autoregressive prediction looping
+        # for the desired number of ar steps.
 
-            # Here we do the autoregressive prediction looping
-            # for the desired number of ar steps.
+        for i in range(batch.num_pred_steps):
+            if not inference:
+                border_state = batch.outputs.tensor[:, i]
 
-            for i in range(batch.num_pred_steps):
-                if not inference:
-                    border_state = batch.outputs.tensor[:, i]
+            if scale_y:
+                step_diff_std, step_diff_mean = self._step_diffs(
+                    self.output_feature_names
+                    if inference
+                    else batch.outputs.feature_names,
+                    prev_states.device,
+                )
 
+            # Intermediary steps for which we have no y_true data
+            # Should be greater or equal to 1 (otherwise nothing is done).
+            for k in range(num_inter_steps):
+                x = self._next_x(batch, prev_states, i)
+                # Graph (B, N_grid, d_f) or Conv (B, N_lat,N_lon d_f)
+                y = self.model(x)
+
+                # We update the latest of our prev_states with the network output
                 if scale_y:
-                    step_diff_std, step_diff_mean = self._step_diffs(
-                        self.output_feature_names
-                        if inference
-                        else batch.outputs.feature_names,
-                        prev_states.device,
+                    predicted_state = (
+                        prev_states[:, -1] + y * step_diff_std + step_diff_mean
                     )
+                else:
+                    predicted_state = prev_states[:, -1] + y
 
-                # Intermediary steps for which we have no y_true data
-                # Should be greater or equal to 1 (otherwise nothing is done).
-                for k in range(num_inter_steps):
-                    x = self._next_x(batch, prev_states, i)
-                    # Graph (B, N_grid, d_f) or Conv (B, N_lat,N_lon d_f)
-                    y = self.model(x)
+                # Overwrite border with true state
+                # Force it to true state for all intermediary step
+                if not inference and force_border:
+                    new_state = (
+                        self.border_mask * border_state
+                        + self.interior_mask * predicted_state
+                    )
+                else:
+                    new_state = predicted_state
 
-                    # We update the latest of our prev_states with the network output
-                    if scale_y:
-                        predicted_state = (
-                            prev_states[:, -1] + y * step_diff_std + step_diff_mean
-                        )
-                    else:
-                        predicted_state = prev_states[:, -1] + y
+                # Only update the prev_states if we are not at the last step
+                if i < batch.num_pred_steps - 1 or k < num_inter_steps - 1:
+                    # Update input states for next iteration: drop oldest, append new_state
+                    prev_states = torch.cat(
+                        [prev_states[:, 1:], new_state.unsqueeze(1)], dim=1
+                    )
+            # Append prediction to prediction list only "normal steps"
+            prediction_list.append(new_state)
 
-                    # Overwrite border with true state
-                    # Force it to true state for all intermediary step
-                    if not inference and force_border:
-                        new_state = (
-                            self.border_mask * border_state
-                            + self.interior_mask * predicted_state
-                        )
-                    else:
-                        new_state = predicted_state
+        prediction = torch.stack(
+            prediction_list, dim=1
+        )  # Stacking is done on time step. (B, pred_steps, N_grid, d_f) or (B, pred_steps, N_lat, N_lon, d_f)
 
-                    # Only update the prev_states if we are not at the last step
-                    if i < batch.num_pred_steps - 1 or k < num_inter_steps - 1:
-                        # Update input states for next iteration: drop oldest, append new_state
-                        prev_states = torch.cat(
-                            [prev_states[:, 1:], new_state.unsqueeze(1)], dim=1
-                        )
-                # Append prediction to prediction list only "normal steps"
-                prediction_list.append(new_state)
-
-            prediction = torch.stack(
-                prediction_list, dim=1
-            )  # Stacking is done on time step. (B, pred_steps, N_grid, d_f) or (B, pred_steps, N_lat, N_lon, d_f)
-
-            # In inference mode we use a "trained" module which MUST have the output feature names
-            # and the output dim names attributes set.
-            if inference:
-                pred_out = NamedTensor(
-                    prediction.type(self.output_dtype),
-                    self.output_dim_names,
-                    self.output_feature_names,
-                )
-            else:
-                pred_out = NamedTensor.new_like(
-                    prediction.type_as(batch.outputs.tensor), batch.outputs
-                )
-            return pred_out, batch.outputs
+        # In inference mode we use a "trained" module which MUST have the output feature names
+        # and the output dim names attributes set.
+        if inference:
+            pred_out = NamedTensor(
+                prediction.type(self.output_dtype),
+                self.output_dim_names,
+                self.output_feature_names,
+            )
+        else:
+            pred_out = NamedTensor.new_like(
+                prediction.type_as(batch.outputs.tensor), batch.outputs
+            )
+        return pred_out, batch.outputs
 
     def on_train_start(self):
         self.train_plotters = []

--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -9,11 +9,6 @@ import warnings
 from dataclasses import dataclass
 from typing import Sequence, Tuple, Union
 
-# Set the environment variable PY4CAST_FORCE_FLASH_ATTN to True to use Tri dao's flash attention
-# Useful to check if we have tensors in bf16 or fp16 because it raises an error otherwise
-force_flash_attn = os.environ.get("PY4CAST_FORCE_FLASH_ATTN", False)
-if force_flash_attn:
-    from flash_attn import flash_attn_func
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -31,6 +26,12 @@ from torch.nn.functional import scaled_dot_product_attention
 
 from py4cast.models.base import ModelABC
 from py4cast.models.vision.utils import features_last_to_second, features_second_to_last
+
+# Set the environment variable PY4CAST_FORCE_FLASH_ATTN to True to use Tri dao's flash attention
+# Useful to check if we have tensors in bf16 or fp16 because it raises an error otherwise
+force_flash_attn = os.environ.get("PY4CAST_FORCE_FLASH_ATTN", False)
+if force_flash_attn:
+    from flash_attn import flash_attn_func
 
 
 def _trunc_normal_(tensor, mean, std, a, b):

--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -4,7 +4,6 @@ Adapted from https://github.com/Amshaker/unetr_plus_plus
 """
 
 import math
-import os
 import warnings
 from dataclasses import dataclass
 from typing import Sequence, Tuple, Union

--- a/py4cast/observer.py
+++ b/py4cast/observer.py
@@ -185,7 +185,7 @@ class PredictionTimestepPlot(MapPlot):
                 plot_prediction(
                     pred_t[:, :, var_i],
                     target_t[:, :, var_i],
-                    obj.interior_2d[:, :, 0],
+                    obj.interior_2d[:, :, 0].type(torch.float32),
                     title=f"{var_name} ({var_unit}), "
                     f"t={t_i} ({obj.hparams['hparams'].dataset_info.step_duration*t_i} h)",
                     vrange=var_vrange,
@@ -240,7 +240,7 @@ class PredictionEpochPlot(MapPlot):
             plot_prediction(
                 pred_t[:, :, var_i],
                 target_t[:, :, var_i],
-                obj.interior_2d[:, :, 0],
+                obj.interior_2d[:, :, 0].type(torch.float32),
                 title=f"{var_name} ({var_unit}), "
                 f"t={max_step} ({leadtime} h) - epoch {obj.current_epoch}",
                 vrange=var_vrange,
@@ -393,7 +393,7 @@ class SpatialErrorPlot(ErrorObserver):
             loss_map_figs = [
                 plot_spatial_error(
                     loss_map,
-                    obj.interior_2d[:, :, 0],
+                    obj.interior_2d[:, :, 0].type(torch.float32),
                     title=f"{self.prefix} loss, t={t_i} ({obj.hparams['hparams'].dataset_info.step_duration*t_i} h)",
                     domain_info=obj.hparams["hparams"].dataset_info.domain_info,
                 )

--- a/py4cast/observer.py
+++ b/py4cast/observer.py
@@ -185,7 +185,7 @@ class PredictionTimestepPlot(MapPlot):
                 plot_prediction(
                     pred_t[:, :, var_i],
                     target_t[:, :, var_i],
-                    obj.interior_2d[:, :, 0].type(torch.float32),
+                    obj.interior_2d[:, :, 0],
                     title=f"{var_name} ({var_unit}), "
                     f"t={t_i} ({obj.hparams['hparams'].dataset_info.step_duration*t_i} h)",
                     vrange=var_vrange,
@@ -240,7 +240,7 @@ class PredictionEpochPlot(MapPlot):
             plot_prediction(
                 pred_t[:, :, var_i],
                 target_t[:, :, var_i],
-                obj.interior_2d[:, :, 0].type(torch.float32),
+                obj.interior_2d[:, :, 0],
                 title=f"{var_name} ({var_unit}), "
                 f"t={max_step} ({leadtime} h) - epoch {obj.current_epoch}",
                 vrange=var_vrange,
@@ -393,7 +393,7 @@ class SpatialErrorPlot(ErrorObserver):
             loss_map_figs = [
                 plot_spatial_error(
                     loss_map,
-                    obj.interior_2d[:, :, 0].type(torch.float32),
+                    obj.interior_2d[:, :, 0],
                     title=f"{self.prefix} loss, t={t_i} ({obj.hparams['hparams'].dataset_info.step_duration*t_i} h)",
                     domain_info=obj.hparams["hparams"].dataset_info.domain_info,
                 )

--- a/py4cast/utils.py
+++ b/py4cast/utils.py
@@ -52,3 +52,11 @@ def merge_dicts(d1: Dict, d2: Dict) -> Dict:
         else:
             d1[key] = d2[key]
     return d1
+
+
+str_to_dtype = {
+    "bf16": torch.bfloat16,
+    "16": torch.float16,
+    "32": torch.float32,
+    "64": torch.float64,
+}


### PR DESCRIPTION
* Makes the training system works with both float-32 and bf16
* Adds utility methods to lightning to cast all trainable parameters and also registered buffers
* Adds a env var to force usage of Tri Dao's flash attention as a drop in replacement of torch's scaled_dot_product_attention (useful because the latter works for both f32 and bf16 whereas flash_attn raises if not f1p6 or bf16)
* Adds flash_attn to Dockerfile
* Tested on EWC A100, including inference

Note: I tried to use the lighting features (trainer's precision, init_module context manager) to let it handle automagicaly the conversion but so far it didn't work.