### PR TITLE
adds torch's pin_memory support to py4cast

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage run -p bin/train.py --model halfunet --model_conf config/models/halfunet32.json --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1 --strategy scaled_ar
         coverage run -p bin/inference.py --dataset dummy --model_path /home/runner/work/py4cast/py4cast/logs/camp0/dummy/halfunet/runn_run_0/
-        coverage run -p bin/train.py --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
+        coverage run -p bin/train.py --model hilam --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1 --pin_memory
         coverage run -p bin/train.py --model unetrpp --dataset dummy --epochs 1 --batch_size 1 --num_pred_steps_train 1 --limit_train_batches 1 --num_workers 1
         coverage combine
         coverage report  --ignore-errors --fail-under=60

--- a/bin/train.py
+++ b/bin/train.py
@@ -202,7 +202,6 @@ parser.add_argument(
 )
 
 args, other = parser.parse_known_args()
-print(args.pin_memory)
 username = getpass.getuser()
 date = datetime.now()
 

--- a/bin/train.py
+++ b/bin/train.py
@@ -193,8 +193,16 @@ parser.add_argument(
     default="run",
     help="Name of the run.",
 )
+parser.add_argument(
+    "--pin_memory",
+    "-pm",
+    action=BooleanOptionalAction,
+    default=False,
+    help="Use pin_memory in dataloader",
+)
 
 args, other = parser.parse_known_args()
+print(args.pin_memory)
 username = getpass.getuser()
 date = datetime.now()
 
@@ -222,6 +230,7 @@ dl_settings = TorchDataloaderSettings(
     batch_size=args.batch_size,
     num_workers=args.num_workers,
     prefetch_factor=args.prefetch_factor,
+    pin_memory=args.pin_memory,
 )
 train_ds, val_ds, test_ds = datasets
 train_loader = train_ds.torch_dataloader(dl_settings)

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -293,6 +293,12 @@ class NamedTensor(TensorWrapper):
     def device(self) -> torch.device:
         return self.tensor.device
 
+    def pin_memory_(self):
+        """
+        'In place' operation to pin the underlying tensor to memory.
+        """
+        self.tensor = self.tensor.pin_memory()
+
 
 @dataclass(slots=True)
 class Item:
@@ -306,6 +312,16 @@ class Item:
     inputs: NamedTensor
     forcing: NamedTensor
     outputs: NamedTensor
+
+    def pin_memory(self):
+        """
+        Custom Item must implement this method to pin the underlying tensors to memory.
+        See https://pytorch.org/docs/stable/data.html#memory-pinning
+        """
+        self.inputs.pin_memory_()
+        self.forcing.pin_memory_()
+        self.outputs.pin_memory_()
+        return self
 
     def __post_init__(self):
         """

--- a/py4cast/datasets/dummy.py
+++ b/py4cast/datasets/dummy.py
@@ -161,6 +161,7 @@ class DummyDataset(DatasetABC, Dataset):
             shuffle=self.shuffle,
             prefetch_factor=tl_settings.prefetch_factor,
             collate_fn=collate_fn,
+            pin_memory=tl_settings.pin_memory,
         )
 
     @cached_property

--- a/py4cast/datasets/poesy.py
+++ b/py4cast/datasets/poesy.py
@@ -655,6 +655,7 @@ class PoesyDataset(DatasetABC, Dataset):
             shuffle=self.shuffle,
             prefetch_factor=tl_settings.prefetch_factor,
             collate_fn=collate_fn,
+            pin_memory=tl_settings.pin_memory,
         )
 
     @property

--- a/py4cast/datasets/smeagol.py
+++ b/py4cast/datasets/smeagol.py
@@ -683,6 +683,7 @@ class SmeagolDataset(DatasetABC, Dataset):
             shuffle=self.shuffle,
             prefetch_factor=tl_settings.prefetch_factor,
             collate_fn=collate_fn,
+            pin_memory=tl_settings.pin_memory,
         )
 
     @property

--- a/py4cast/datasets/titan/__init__.py
+++ b/py4cast/datasets/titan/__init__.py
@@ -679,6 +679,7 @@ class TitanDataset(DatasetABC, Dataset):
             shuffle=self.shuffle,
             prefetch_factor=tl_settings.prefetch_factor,
             collate_fn=collate_fn,
+            pin_memory=tl_settings.pin_memory,
         )
 
     @property


### PR DESCRIPTION
* Adds a pin_memory_ method to NamedTensor to replace the underlying tensor with a memory pinned copy
* Adds a pin_memory method to our custom Item/ItemBatch (see https://pytorch.org/docs/stable/data.html#memory-pinning)
* Adds a pin_memory arg to the training script
* Makes sure we test it at least once in the CI