### PR TITLE
Refactoring Titan cache dir and preparation + fix memory leak when computing stats

### DIFF
--- a/bin/train.py
+++ b/bin/train.py
@@ -248,19 +248,16 @@ else:
     len_loader = len(train_loader)
 
 # Get Log folders
-if args.no_log:
-    save_path = None
-else:
-    log_dir = ROOTDIR / "logs"
-    folder = Path(args.campaign_name) / args.dataset / args.model
-    run_name = f"{username[:4]}_{args.run_name}"
-    if args.dev_mode:
-        run_name += "_dev"
-    list_subdirs = list((log_dir / folder).glob(f"{run_name}*"))
-    list_versions = sorted([int(d.name.split("_")[-1]) for d in list_subdirs])
-    version = 0 if list_subdirs == [] else list_versions[-1] + 1
-    subfolder = f"{run_name}_{version}"
-    save_path = log_dir / folder / subfolder
+log_dir = ROOTDIR / "logs"
+folder = Path(args.campaign_name) / args.dataset / args.model
+run_name = f"{username[:4]}_{args.run_name}"
+if args.dev_mode:
+    run_name += "_dev"
+list_subdirs = list((log_dir / folder).glob(f"{run_name}*"))
+list_versions = sorted([int(d.name.split("_")[-1]) for d in list_subdirs])
+version = 0 if list_subdirs == [] else list_versions[-1] + 1
+subfolder = f"{run_name}_{version}"
+save_path = log_dir / folder / subfolder
 
 
 hp = ArLightningHyperParam(

--- a/bin/train.py
+++ b/bin/train.py
@@ -249,7 +249,7 @@ else:
 
 # Get Log folders
 if args.no_log:
-    save_path=None
+    save_path = None
 else:
     log_dir = ROOTDIR / "logs"
     folder = Path(args.campaign_name) / args.dataset / args.model

--- a/bin/train.py
+++ b/bin/train.py
@@ -56,7 +56,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--dataset_conf",
-    type=str,  # Union[str, None] # Union does not work from CLI.
+    type=Path,  # Union[str, None] # Union does not work from CLI.
     default=None,
     help="Configuration file for the dataset. If None, default configuration is used.",
 )
@@ -248,16 +248,19 @@ else:
     len_loader = len(train_loader)
 
 # Get Log folders
-log_dir = ROOTDIR / "logs"
-folder = Path(args.campaign_name) / args.dataset / args.model
-run_name = f"{username[:4]}_{args.run_name}"
-if args.dev_mode:
-    run_name += "_dev"
-list_subdirs = list((log_dir / folder).glob(f"{run_name}*"))
-list_versions = sorted([int(d.name.split("_")[-1]) for d in list_subdirs])
-version = 0 if list_subdirs == [] else list_versions[-1] + 1
-subfolder = f"{run_name}_{version}"
-save_path = log_dir / folder / subfolder
+if args.no_log:
+    save_path=None
+else:
+    log_dir = ROOTDIR / "logs"
+    folder = Path(args.campaign_name) / args.dataset / args.model
+    run_name = f"{username[:4]}_{args.run_name}"
+    if args.dev_mode:
+        run_name += "_dev"
+    list_subdirs = list((log_dir / folder).glob(f"{run_name}*"))
+    list_versions = sorted([int(d.name.split("_")[-1]) for d in list_subdirs])
+    version = 0 if list_subdirs == [] else list_versions[-1] + 1
+    subfolder = f"{run_name}_{version}"
+    save_path = log_dir / folder / subfolder
 
 
 hp = ArLightningHyperParam(

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -625,7 +625,7 @@ class DatasetABC(ABC):
         n_features = len(random_inputs.feature_names)
         sum_means = torch.zeros(n_features)
         sum_squares = torch.zeros(n_features)
-        flat_input = random_inputs.tensor.flatten(0, 3) # (X, Features)
+        flat_input = random_inputs.tensor.flatten(0, 3)  # (X, Features)
         best_min = torch.min(flat_input, dim=0).values
         best_max = torch.max(flat_input, dim=0).values
         counter = 0
@@ -720,7 +720,7 @@ class DatasetABC(ABC):
 
         diff_mean = sum_means / counter
         diff_second_moment = sum_squares / counter
-        diff_std = torch.sqrt(diff_second_moment - diff_mean ** 2)  # (d_features)
+        diff_std = torch.sqrt(diff_second_moment - diff_mean**2)  # (d_features)
         store_d = {}
 
         # Storing variable statistics

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -621,10 +621,14 @@ class DatasetABC(ABC):
         """
         Compute mean and standard deviation for this dataset.
         """
-        means = []
-        squares = []
-        mins = []
-        maxs = []
+        random_inputs = next(iter(self.torch_dataloader())).inputs
+        n_features = len(random_inputs.feature_names)
+        sum_means = torch.zeros(n_features)
+        sum_squares = torch.zeros(n_features)
+        flat_input = random_inputs.tensor.flatten(0, 3) # (X, Features)
+        best_min = torch.min(flat_input, dim=0).values
+        best_max = torch.max(flat_input, dim=0).values
+        counter = 0
         print(
             "We are going to compute statistics on the dataset. This can take a while."
         )
@@ -634,7 +638,6 @@ class DatasetABC(ABC):
         for batch in tqdm(self.torch_dataloader(), desc="Computing stats"):
 
             # Here we assume that data are in 2 or 3 D
-
             inputs = batch.inputs.tensor
             outputs = batch.outputs.tensor
 
@@ -650,44 +653,51 @@ class DatasetABC(ABC):
                 1, 3
             )  # Flatten everybody to be (Batch, X, Features)
 
-            means.append(in_out.mean(dim=1))
-            squares.append((in_out**2).mean(dim=1))
-            maxi, _ = torch.max(in_out, 1)
-            mini, _ = torch.min(in_out, 1)
-            mins.append(mini)  # (N_batch, d_features,)
-            maxs.append(maxi)  # (N_batch, d_features,)
+            counter += in_out.shape[0]  # += batch size
 
-        mean = torch.mean(torch.cat(means, dim=0), dim=0)  # (d_features)
-        second_moment = torch.mean(torch.cat(squares, dim=0), dim=0)
+            sum_means += torch.sum(in_out.mean(dim=1), dim=0)  # (d_features)
+            sum_squares += torch.sum((in_out**2).mean(dim=1), dim=0)  # (d_features)
+
+            mini = torch.min(in_out, 1).values[0]
+            stack_mini = torch.stack([best_min, mini], dim=0)
+            best_min = torch.min(stack_mini, dim=0).values  # (d_features)
+
+            maxi = torch.max(in_out, 1).values[0]
+            stack_maxi = torch.stack([best_max, maxi], dim=0)
+            best_max = torch.max(stack_maxi, dim=0).values  # (d_features)
+
+        mean = sum_means / counter
+        second_moment = sum_squares / counter
         std = torch.sqrt(second_moment - mean**2)  # (d_features)
-        maxi, _ = torch.max(torch.cat(maxs, dim=0), dim=0)
-        mini, _ = torch.min(torch.cat(mins, dim=0), dim=0)
-
-        # Store in dictionnary
-        store_d = {}
 
         # Storing variable statistics
+        store_d = {}
         for i, name in enumerate(batch.inputs.feature_names):
             store_d[name] = {
                 "mean": mean[i],
                 "std": std[i],
-                "min": mini[i],
-                "max": maxi[i],
+                "min": best_min[i],
+                "max": best_max[i],
             }
-        torch_save(store_d, self.cache_dir / "parameters_stats.pt")
+        dest_file = self.cache_dir / "parameters_stats.pt"
+        torch_save(store_d, dest_file)
+        print(f"Parameters statistics saved in {dest_file}")
 
     def compute_time_step_stats(self):
-        diff_means = []
-        diff_squares = []
+        random_inputs = next(iter(self.torch_dataloader())).inputs
+        n_features = len(random_inputs.feature_names)
+        sum_means = torch.zeros(n_features)
+        sum_squares = torch.zeros(n_features)
+        counter = 0
         if not self.settings.standardize:
             print(
                 f"Your dataset {self} is not normalized. If you do not normalized your output it could be intended."
             )
             print("Otherwise consider standardizing your inputs.")
+
         for batch in tqdm(self.torch_dataloader()):
 
-            # Here we postpone that data are in 2 or 3 D
-
+            # Here we assume that data are in 2 or 3 D
             inputs = batch.inputs.tensor
             outputs = batch.outputs.tensor
 
@@ -704,14 +714,13 @@ class DatasetABC(ABC):
             )  # Substract information on time dimension
             diff = diff.flatten(1, 3)  # Flatten everybody to be (Batch, X, Features)
 
-            diff_means.append(diff.mean(dim=1))
-            diff_squares.append((diff**2).mean(dim=1))
+            counter += in_out.shape[0]  # += batch size
+            sum_means += torch.sum(diff.mean(dim=1), dim=0)  # (d_features)
+            sum_squares += torch.sum((diff**2).mean(dim=1), dim=0)  # (d_features)
 
-        # This should not work
-        # We should be aware that dataset shoul
-        diff_mean = torch.mean(torch.cat(diff_means, dim=0), dim=0)
-        diff_second_moment = torch.mean(torch.cat(diff_squares, dim=0), dim=0)
-        diff_std = torch.sqrt(diff_second_moment - diff_mean**2)  # (d_features)
+        diff_mean = sum_means / counter
+        diff_second_moment = sum_squares / counter
+        diff_std = torch.sqrt(diff_second_moment - diff_mean ** 2)  # (d_features)
         store_d = {}
 
         # Storing variable statistics
@@ -720,7 +729,9 @@ class DatasetABC(ABC):
                 "mean": diff_mean[i],
                 "std": diff_std[i],
             }
+        dest_file = self.cache_dir / "diff_stats.pt"
         torch_save(store_d, self.cache_dir / "diff_stats.pt")
+        print(f"Parameters time diff stats saved in {dest_file}")
 
     @property
     def dataset_extra_statics(self) -> List[NamedTensor]:

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -625,7 +625,8 @@ class DatasetABC(ABC):
         n_features = len(random_inputs.feature_names)
         sum_means = torch.zeros(n_features)
         sum_squares = torch.zeros(n_features)
-        flat_input = random_inputs.tensor.flatten(0, 3)  # (X, Features)
+        ndim_features = len(random_inputs.tensor.shape) - 1
+        flat_input = random_inputs.tensor.flatten(0, ndim_features - 1)  # (X, Features)
         best_min = torch.min(flat_input, dim=0).values
         best_max = torch.max(flat_input, dim=0).values
         counter = 0

--- a/py4cast/datasets/titan/__init__.py
+++ b/py4cast/datasets/titan/__init__.py
@@ -167,11 +167,6 @@ class Grid:
     def projection(self):
         return cartopy.crs.PlateCarree()
 
-    @property
-    def data_path(self):
-        str_subdomain = "-".join([str(i) for i in self.subdomain])
-        return SCRATCH_PATH / f"dataset_{self.name}_{str_subdomain}"
-
 
 #############################################################
 #                            PARAM                          #
@@ -197,6 +192,7 @@ class Param:
     native_grid: str = field(init=False)
     grib_name: str = field(init=False)
     grib_param: str = field(init=False)
+    npy_path: Path = None
 
     def __post_init__(self):
         param_info = METADATA["WEATHER_PARAMS"][self.name]
@@ -252,9 +248,8 @@ class Param:
             folder = SCRATCH_PATH / "grib" / date.strftime(FORMATSTR)
             return folder / self.grib_name
         else:
-            dataset_path = self.grid.data_path
             filename = f"{self.name}_{self.level}{self.level_type.lower()}.npy"
-            return dataset_path / date.strftime(FORMATSTR) / filename
+            return self.npy_path / date.strftime(FORMATSTR) / filename
 
     def fit_to_grid(self, arr: np.ndarray) -> np.ndarray:
         if self.grid.name == self.native_grid:
@@ -287,6 +282,22 @@ class Param:
     def exist(self, date: dt.datetime, file_format: Literal["npy", "grib"] = "grib"):
         filepath = self.get_filepath(date, file_format)
         return filepath.exists()
+
+
+def process_sample_dataset(date: dt.datetime, params: List[Param]):
+    """Saves each 2D parameter data of the given date as one NPY file."""
+    for param in params:
+        dest_file = param.get_filepath(date, "npy")
+        dest_file.parent.mkdir(exist_ok=True)
+        if not dest_file.exists():
+            try:
+                arr = param.load_data(date, "grib")
+                np.save(dest_file, arr)
+            except Exception as e:
+                print(e)
+                print(
+                    f"WARNING: Could not load grib data {param.name} {param.level} {date}. Skipping."
+                )
 
 
 #############################################################
@@ -492,13 +503,27 @@ class Sample:
 #                            DATASET                        #
 #############################################################
 
+def get_dataset_path(name:str, grid:Grid):
+    str_subdomain = "-".join([str(i) for i in grid.subdomain])
+    subdataset_name = f"{name}_{grid.name}_{str_subdomain}"
+    return SCRATCH_PATH / "subdatasets" / subdataset_name
+
+def get_param_list(conf: dict, grid: Grid, dataset_path:Path) -> List[Param]:
+    param_list = []
+    for name, values in conf["params"].items():
+        for lvl in values["levels"]:
+            param = Param(name=name, level=lvl, kind=values["kind"], grid=grid, npy_path=dataset_path / "data")
+            param_list.append(param)
+    return param_list
+
 
 class TitanDataset(DatasetABC, Dataset):
     # Si on doit travailler avec plusieurs grilles, on fera un super dataset qui contient
     # plusieurs datasets chacun sur une seule grille
     def __init__(
-        self, grid: Grid, period: Period, params: List[Param], settings: TitanSettings
+        self, name:str, grid: Grid, period: Period, params: List[Param], settings: TitanSettings
     ):
+        self.name = name
         self.grid = grid
         if grid.name not in ["PAAROME_1S100", "PAAROME_1S40"]:
             raise NotImplementedError(
@@ -507,13 +532,12 @@ class TitanDataset(DatasetABC, Dataset):
         self.period = period
         self.params = params
         self.settings = settings
-        self._cache_dir = CACHE_DIR / "datasets" / str(self)
         self.shuffle = self.period.name == "train"
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         n_input, n_pred = self.settings.num_input_steps, self.settings.num_pred_steps
         filename = f"valid_samples_{self.period.name}_{n_input}_{n_pred}.txt"
-        self.valid_samples_file = self._cache_dir / filename
+        self.valid_samples_file = self.cache_dir / filename
 
     @cached_property
     def dataset_info(self) -> DatasetInfo:
@@ -613,40 +637,35 @@ class TitanDataset(DatasetABC, Dataset):
         item = sample.load()
         return item
 
-    @classmethod
-    def get_param_list(cls, conf: dict, grid: Grid) -> List[Param]:
-        param_list = []
-        for name, values in conf["params"].items():
-            for lvl in values["levels"]:
-                param = Param(name=name, level=lvl, kind=values["kind"], grid=grid)
-                param_list.append(param)
-        return param_list
+    
 
     @classmethod
     def from_dict(
         cls,
+        name:str,
         conf: dict,
         num_input_steps: int,
         num_pred_steps_train: int,
         num_pred_steps_val_test: int,
     ) -> Tuple["TitanDataset", "TitanDataset", "TitanDataset"]:
         grid = Grid(**conf["grid"])
-        param_list = cls.get_param_list(conf, grid)
+        dataset_path = get_dataset_path(name, grid)
+        param_list = get_param_list(conf, grid, dataset_path)
 
         train_settings = TitanSettings(
             num_input_steps, num_pred_steps_train, **conf["settings"]
         )
         train_period = Period(**conf["periods"]["train"], name="train")
-        train_ds = TitanDataset(grid, train_period, param_list, train_settings)
+        train_ds = TitanDataset(name, grid, train_period, param_list, train_settings)
 
         valid_settings = TitanSettings(
             num_input_steps, num_pred_steps_val_test, **conf["settings"]
         )
         valid_period = Period(**conf["periods"]["valid"], name="valid")
-        valid_ds = TitanDataset(grid, valid_period, param_list, valid_settings)
+        valid_ds = TitanDataset(name, grid, valid_period, param_list, valid_settings)
 
         test_period = Period(**conf["periods"]["test"], name="test")
-        test_ds = TitanDataset(grid, test_period, param_list, valid_settings)
+        test_ds = TitanDataset(name, grid, test_period, param_list, valid_settings)
         return train_ds, valid_ds, test_ds
 
     @classmethod
@@ -663,7 +682,7 @@ class TitanDataset(DatasetABC, Dataset):
             if config_override is not None:
                 conf = merge_dicts(conf, config_override)
         return cls.from_dict(
-            conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
+            fname.stem, conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
         )
 
     def __str__(self) -> str:
@@ -743,7 +762,7 @@ class TitanDataset(DatasetABC, Dataset):
 
     @property
     def cache_dir(self) -> Path:
-        return self._cache_dir
+        return get_dataset_path(self.name, self.grid)
 
     @cached_property
     def domain_info(self) -> DomainInfo:
@@ -752,36 +771,6 @@ class TitanDataset(DatasetABC, Dataset):
             grid_limits=self.grid.grid_limits, projection=self.grid.projection
         )
 
-    @classmethod
-    def prepare(
-        cls,
-        path_config: Path,
-        num_input_steps: int,
-        num_pred_steps_train: int,
-        num_pred_steps_val_test: int,
-    ):
-        print("--> Preparing Titan Dataset...")
-
-        print("Load train dataset configuration...")
-        with open(path_config, "r") as fp:
-            conf = json.load(fp)
-
-        print("Computing stats on each parameter...")
-        conf["settings"]["standardize"] = False
-        train_ds, valid_ds, test_ds = TitanDataset.from_dict(
-            conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
-        )
-        train_ds.write_list_valid_samples()
-        valid_ds.write_list_valid_samples()
-        test_ds.write_list_valid_samples()
-        train_ds.compute_parameters_stats()
-
-        print("Computing time stats on each parameters, between 2 timesteps...")
-        conf["settings"]["standardize"] = True
-        train_ds, valid_ds, test_ds = TitanDataset.from_dict(
-            conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
-        )
-        train_ds.compute_time_step_stats()
 
 
 @app.command()
@@ -792,51 +781,51 @@ def prepare(
     num_pred_steps_val_test: int = 3,
 ):
     """Prepares Titan by computing statistics on all weather parameters."""
-    TitanDataset.prepare(
-        path_config, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
-    )
+    print("--> Preparing Titan Dataset...")
 
-
-def process_sample_dataset(date_folder: str, params: List[Param]):
-    """Saves each 2D parameter data of the given date as one NPY file."""
-    date = dt.datetime.strptime(date_folder, "%Y-%m-%d_%Hh%M")
-    for param in params:
-        dest_file = param.get_filepath(date, "npy")
-        dest_file.parent.mkdir(exist_ok=True)
-        if not dest_file.exists():
-            try:
-                arr = param.load_data(date, "grib")
-                np.save(dest_file, arr)
-            except Exception as e:
-                print(e)
-                print(
-                    f"WARNING: Could not load data {param.name} {param.level} {date}. Skipping."
-                )
-
-
-@app.command()
-def conv_npy_and_rescale(path_config: Path = DEFAULT_CONFIG, num_workers: int = 1):
-    """Prepares Titan files by rescaling, cropping fields and saving as npy."""
+    print("Load dataset configuration...")
     with open(path_config, "r") as fp:
         conf = json.load(fp)
 
-    grid = Grid(**conf["grid"])
-    grid.data_path.mkdir(exist_ok=True)
-    src_path = SCRATCH_PATH / "grib"
-    print(f"Preparing {grid.data_path.name}...")
-    print(f"Source data: {src_path}")
-
-    param_list = TitanDataset.get_param_list(conf, grid)
-
-    date_folders = [path.name for path in sorted(list(src_path.glob("*")))]
-    # We use "threads" to avoid _pickle.PicklingError: Could not pickle the task to send it to the workers
-    # see https://stackoverflow.com/questions/56884020/
-    # spacy-with-joblib-library-generates-pickle-picklingerror-could-not-pickle-the
-    Parallel(n_jobs=num_workers, prefer="threads")(
-        delayed(process_sample_dataset)(fld, param_list)
-        for fld in tqdm.tqdm(date_folders)
+    print("Creating folders...")
+    train_ds, valid_ds, test_ds = TitanDataset.from_dict(
+        path_config.stem, conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
     )
-    print(f"Dataset saved in {grid.data_path.name}")
+    train_ds.cache_dir.mkdir(exist_ok=True)
+    data_dir = train_ds.cache_dir / "data"
+    data_dir.mkdir(exist_ok=True)
+    print(f"Dataset will be saved in {train_ds.cache_dir}")
+
+    print("Converting gribs to npy...")
+    src_path = SCRATCH_PATH / "grib"
+    param_list = get_param_list(conf, train_ds.grid, train_ds.cache_dir)
+    sum_dates = list(train_ds.period.date_list) + list(valid_ds.period.date_list) + list(test_ds.period.date_list)
+    dates = list(set(sum_dates))
+    print(f"{len(dates)} samples to convert")
+    for date in tqdm.tqdm(dates):
+        process_sample_dataset(date, param_list)
+    print("Done!")
+
+    print("Computing stats on each parameter...")
+    conf["settings"]["standardize"] = False
+    train_ds, valid_ds, test_ds = TitanDataset.from_dict(
+        path_config.stem, conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
+    )
+    print("len(train_ds) : ",len(train_ds))
+    train_ds.compute_parameters_stats()
+    print("Done!")
+    train_ds.write_list_valid_samples()
+    valid_ds.write_list_valid_samples()
+    test_ds.write_list_valid_samples()
+
+    print("Computing time stats on each parameters, between 2 timesteps...")
+    conf["settings"]["standardize"] = True
+    train_ds, valid_ds, test_ds = TitanDataset.from_dict(
+        path_config.stem, conf, num_input_steps, num_pred_steps_train, num_pred_steps_val_test
+    )
+    train_ds.compute_time_step_stats()
+
+
 
 
 @app.command()

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -224,11 +224,11 @@ class AutoRegressiveLightning(pl.LightningModule):
             dict_log["username"] = getpass.getuser()
             self.logger.log_hyperparams(dict_log, metrics={"val_mean_loss": 0.0})
             # Save model & dataset conf as files
-            if hparams.dataset_conf is not None:
+            if hparams.dataset_conf is not None and hparams.save_path:
                 shutil.copyfile(
                     hparams.dataset_conf, hparams.save_path / "dataset_conf.json"
                 )
-            if hparams.model_conf is not None:
+            if hparams.model_conf is not None and hparams.save_path:
                 shutil.copyfile(
                     hparams.model_conf, hparams.save_path / "model_conf.json"
                 )

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -224,11 +224,11 @@ class AutoRegressiveLightning(pl.LightningModule):
             dict_log["username"] = getpass.getuser()
             self.logger.log_hyperparams(dict_log, metrics={"val_mean_loss": 0.0})
             # Save model & dataset conf as files
-            if hparams.dataset_conf is not None and hparams.save_path:
+            if hparams.dataset_conf is not None:
                 shutil.copyfile(
                     hparams.dataset_conf, hparams.save_path / "dataset_conf.json"
                 )
-            if hparams.model_conf is not None and hparams.save_path:
+            if hparams.model_conf is not None:
                 shutil.copyfile(
                     hparams.model_conf, hparams.save_path / "model_conf.json"
                 )


### PR DESCRIPTION
- Fix memory leak when computing stats by adding an accumulator and a counter to compute means, squares, min and max.
- Titan can now handle different versions of itself : versions are stored in `TITAN_ROOT_DIR/subdatasets/` and named after their config file and grid. For instance `titan_full_PAAROME_1S40_100-612-240-880`
- Parameters stats and time diff stats are now stored in the aforementioned folder and depend on the version of the dataset
- The titan `prepare` command now handles : converting gribs to npy, computing stats and checking chich samples are valid.