### PR TITLE
Fixes no_log mode by ignoring all plot and log ops

### DIFF
--- a/bin/train.py
+++ b/bin/train.py
@@ -278,6 +278,7 @@ hp = ArLightningHyperParam(
     save_path=save_path,
     use_lr_scheduler=args.use_lr_scheduler,
     precision=args.precision,
+    no_log=args.no_log,
 )
 
 # Logger & checkpoint callback
@@ -306,7 +307,9 @@ else:
     )
     callback_list.append(checkpoint_callback)
     callback_list.append(LearningRateMonitor(logging_interval="step"))
-callback_list.append(EarlyStopping(monitor="val_mean_loss", mode="min", patience=50))
+    callback_list.append(
+        EarlyStopping(monitor="val_mean_loss", mode="min", patience=50)
+    )
 
 # Setup profiler
 if args.profiler == "pytorch":

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -214,7 +214,7 @@ class AutoRegressiveLightning(pl.LightningModule):
 
         save_path = self.hparams["hparams"].save_path
         max_pred_step = self.hparams["hparams"].num_pred_steps_val_test - 1
-        if not self.hparams["hparams"].no_log:
+        if self.logging_enabled:
             self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)
             self.psd_plot_metric = MetricPSDK(save_path, pred_step=max_pred_step)
             self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -65,6 +65,7 @@ class ArLightningHyperParam:
     save_path: Path = None
     use_lr_scheduler: bool = False
     precision: str = "bf16"
+    no_log: bool = False
 
     def __post_init__(self):
         """
@@ -213,9 +214,10 @@ class AutoRegressiveLightning(pl.LightningModule):
 
         save_path = self.hparams["hparams"].save_path
         max_pred_step = self.hparams["hparams"].num_pred_steps_val_test - 1
-        self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)
-        self.psd_plot_metric = MetricPSDK(save_path, pred_step=max_pred_step)
-        self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
+        if not self.hparams["hparams"].no_log:
+            self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)
+            self.psd_plot_metric = MetricPSDK(save_path, pred_step=max_pred_step)
+            self.acc_metric = MetricACC(self.hparams["hparams"].dataset_info)
 
     @property
     def dtype(self):
@@ -463,9 +465,10 @@ class AutoRegressiveLightning(pl.LightningModule):
         """Computes and logs the averaged metrics at the end of an epoch.
         Step shared by training and validation epochs.
         """
-        avg_loss = torch.stack([x for x in outputs]).mean()
-        tb = self.logger.experiment
-        tb.add_scalar(f"mean_loss_epoch/{label}", avg_loss, self.current_epoch)
+        if self.logging_enabled:
+            avg_loss = torch.stack([x for x in outputs]).mean()
+            tb = self.logger.experiment
+            tb.add_scalar(f"mean_loss_epoch/{label}", avg_loss, self.current_epoch)
 
     def training_step(self, batch: ItemBatch, batch_idx: int) -> torch.Tensor:
         """
@@ -488,10 +491,18 @@ class AutoRegressiveLightning(pl.LightningModule):
         self.training_step_losses.append(batch_loss)
 
         # Notify every plotters
-        for plotter in self.train_plotters:
-            plotter.update(self, prediction=self.prediction, target=self.target)
+        if self.logging_enabled:
+            for plotter in self.train_plotters:
+                plotter.update(self, prediction=self.prediction, target=self.target)
 
         return batch_loss
+
+    @property
+    def logging_enabled(self):
+        """
+        Check if logging is enabled
+        """
+        return not self.hparams["hparams"].no_log
 
     def on_save_checkpoint(self, checkpoint):
         """
@@ -539,25 +550,28 @@ class AutoRegressiveLightning(pl.LightningModule):
         """
         Add some observers when starting validation
         """
-        l1_loss = ScaledLoss("L1Loss", reduction="none")
-        l1_loss.prepare(self, self.interior_mask, self.hparams["hparams"].dataset_info)
-        metrics = {"mae": l1_loss}
-        save_path = self.hparams["hparams"].save_path
-        self.valid_plotters = [
-            StateErrorPlot(metrics, prefix="Validation"),
-            PredictionTimestepPlot(
-                num_samples_to_plot=1,
-                num_features_to_plot=4,
-                prefix="Validation",
-                save_path=save_path,
-            ),
-            PredictionEpochPlot(
-                num_samples_to_plot=1,
-                num_features_to_plot=4,
-                prefix="Validation",
-                save_path=save_path,
-            ),
-        ]
+        if self.logging_enabled:
+            l1_loss = ScaledLoss("L1Loss", reduction="none")
+            l1_loss.prepare(
+                self, self.interior_mask, self.hparams["hparams"].dataset_info
+            )
+            metrics = {"mae": l1_loss}
+            save_path = self.hparams["hparams"].save_path
+            self.valid_plotters = [
+                StateErrorPlot(metrics, prefix="Validation"),
+                PredictionTimestepPlot(
+                    num_samples_to_plot=1,
+                    num_features_to_plot=4,
+                    prefix="Validation",
+                    save_path=save_path,
+                ),
+                PredictionEpochPlot(
+                    num_samples_to_plot=1,
+                    num_features_to_plot=4,
+                    prefix="Validation",
+                    save_path=save_path,
+                ),
+            ]
 
     def _shared_val_test_step(self, batch: ItemBatch, batch_idx, label: str):
         with torch.no_grad():
@@ -566,19 +580,20 @@ class AutoRegressiveLightning(pl.LightningModule):
         time_step_loss = torch.mean(self.loss(prediction, target), dim=0)
         mean_loss = torch.mean(time_step_loss)
 
-        # Log loss per timestep
-        loss_dict = {
-            f"timestep_losses/{label}_step_{step}": time_step_loss[step]
-            for step in range(time_step_loss.shape[0])
-        }
-        self.log_dict(loss_dict, on_epoch=True, sync_dist=True)
-        self.log(
-            f"{label}_mean_loss",
-            mean_loss,
-            on_epoch=True,
-            sync_dist=True,
-            prog_bar=(label == "val"),
-        )
+        if self.logging_enabled:
+            # Log loss per timestep
+            loss_dict = {
+                f"timestep_losses/{label}_step_{step}": time_step_loss[step]
+                for step in range(time_step_loss.shape[0])
+            }
+            self.log_dict(loss_dict, on_epoch=True, sync_dist=True)
+            self.log(
+                f"{label}_mean_loss",
+                mean_loss,
+                on_epoch=True,
+                sync_dist=True,
+                prog_bar=(label == "val"),
+            )
         return prediction, target, mean_loss
 
     def validation_step(self, batch: ItemBatch, batch_idx):
@@ -592,35 +607,41 @@ class AutoRegressiveLightning(pl.LightningModule):
 
         self.val_mean_loss = mean_loss
 
-        # Notify every plotters
-        if self.current_epoch % PLOT_PERIOD == 0:
-            for plotter in self.valid_plotters:
-                plotter.update(self, prediction=prediction, target=target)
-            self.psd_plot_metric.update(prediction, target, self.original_shape)
-            self.rmse_psd_plot_metric.update(prediction, target, self.original_shape)
-            self.acc_metric.update(prediction, target)
+        if self.logging_enabled:
+            # Notify every plotters
+            if self.current_epoch % PLOT_PERIOD == 0:
+                for plotter in self.valid_plotters:
+                    plotter.update(self, prediction=prediction, target=target)
+                self.psd_plot_metric.update(prediction, target, self.original_shape)
+                self.rmse_psd_plot_metric.update(
+                    prediction, target, self.original_shape
+                )
+                self.acc_metric.update(prediction, target)
 
     def on_validation_epoch_end(self):
         """
         Compute val metrics at the end of val epoch
         """
 
-        # Get dict of metrics' results
-        dict_metrics = dict()
-        dict_metrics.update(self.psd_plot_metric.compute())
-        dict_metrics.update(self.rmse_psd_plot_metric.compute())
-        dict_metrics.update(self.acc_metric.compute())
-        for name, elmnt in dict_metrics.items():
-            if isinstance(elmnt, matplotlib.figure.Figure):
-                self.logger.experiment.add_figure(f"{name}", elmnt, self.current_epoch)
-            elif isinstance(elmnt, torch.Tensor):
-                self.log_dict(
-                    {name: elmnt},
-                    prog_bar=False,
-                    on_step=False,
-                    on_epoch=True,
-                    sync_dist=True,
-                )
+        if self.logging_enabled:
+            # Get dict of metrics' results
+            dict_metrics = dict()
+            dict_metrics.update(self.psd_plot_metric.compute())
+            dict_metrics.update(self.rmse_psd_plot_metric.compute())
+            dict_metrics.update(self.acc_metric.compute())
+            for name, elmnt in dict_metrics.items():
+                if isinstance(elmnt, matplotlib.figure.Figure):
+                    self.logger.experiment.add_figure(
+                        f"{name}", elmnt, self.current_epoch
+                    )
+                elif isinstance(elmnt, torch.Tensor):
+                    self.log_dict(
+                        {name: elmnt},
+                        prog_bar=False,
+                        on_step=False,
+                        on_epoch=True,
+                        sync_dist=True,
+                    )
 
         outputs = self.validation_step_losses
         self._shared_epoch_end(outputs, "validation")
@@ -628,33 +649,37 @@ class AutoRegressiveLightning(pl.LightningModule):
         # free memory
         self.validation_step_losses.clear()
 
-        # Notify every plotters
-        if self.current_epoch % PLOT_PERIOD == 0:
-            for plotter in self.valid_plotters:
-                plotter.on_step_end(self, label="Valid")
+        if self.logging_enabled:
+            # Notify every plotters
+            if self.current_epoch % PLOT_PERIOD == 0:
+                for plotter in self.valid_plotters:
+                    plotter.on_step_end(self, label="Valid")
 
     def on_test_start(self):
         """
         Attach observer when starting test
         """
-        metrics = {}
-        for torch_loss, alias in ("L1Loss", "mae"), ("MSELoss", "rmse"):
-            loss = ScaledLoss(torch_loss, reduction="none")
-            loss.prepare(self, self.interior_mask, self.hparams["hparams"].dataset_info)
-            metrics[alias] = loss
+        if self.logging_enabled:
+            metrics = {}
+            for torch_loss, alias in ("L1Loss", "mae"), ("MSELoss", "rmse"):
+                loss = ScaledLoss(torch_loss, reduction="none")
+                loss.prepare(
+                    self, self.interior_mask, self.hparams["hparams"].dataset_info
+                )
+                metrics[alias] = loss
 
-        save_path = self.hparams["hparams"].save_path
+            save_path = self.hparams["hparams"].save_path
 
-        self.test_plotters = [
-            StateErrorPlot(metrics, save_path=save_path),
-            SpatialErrorPlot(),
-            PredictionTimestepPlot(
-                num_samples_to_plot=self.hparams["hparams"].num_samples_to_plot,
-                num_features_to_plot=4,
-                prefix="Test",
-                save_path=save_path,
-            ),
-        ]
+            self.test_plotters = [
+                StateErrorPlot(metrics, save_path=save_path),
+                SpatialErrorPlot(),
+                PredictionTimestepPlot(
+                    num_samples_to_plot=self.hparams["hparams"].num_samples_to_plot,
+                    num_features_to_plot=4,
+                    prefix="Test",
+                    save_path=save_path,
+                ),
+            ]
 
     def test_step(self, batch: ItemBatch, batch_idx):
         """
@@ -662,13 +687,14 @@ class AutoRegressiveLightning(pl.LightningModule):
         """
         prediction, target, _ = self._shared_val_test_step(batch, batch_idx, "test")
 
-        # Notify plotters & metrics
-        for plotter in self.test_plotters:
-            plotter.update(self, prediction=prediction, target=target)
+        if self.logging_enabled:
+            # Notify plotters & metrics
+            for plotter in self.test_plotters:
+                plotter.update(self, prediction=prediction, target=target)
 
-        self.acc_metric.update(prediction, target)
-        self.psd_plot_metric.update(prediction, target, self.original_shape)
-        self.rmse_psd_plot_metric.update(prediction, target, self.original_shape)
+            self.acc_metric.update(prediction, target)
+            self.psd_plot_metric.update(prediction, target, self.original_shape)
+            self.rmse_psd_plot_metric.update(prediction, target, self.original_shape)
 
     @cached_property
     def interior_2d(self) -> torch.Tensor:
@@ -686,14 +712,11 @@ class AutoRegressiveLightning(pl.LightningModule):
         """
         Compute test metrics and make plots at the end of test epoch.
         """
-        # TODO : when running on multiple GPU, the following line throws
-        # "RuntimeError: No backend type associated with device type cpu"
-        # see: https://github.com/Lightning-AI/torchmetrics/issues/2477
-        # and: https://github.com/Lightning-AI/pytorch-lightning/issues/18803
-        self.psd_plot_metric.compute()
-        self.rmse_psd_plot_metric.compute()
-        self.acc_metric.compute()
+        if self.logging_enabled:
+            self.psd_plot_metric.compute()
+            self.rmse_psd_plot_metric.compute()
+            self.acc_metric.compute()
 
-        # Notify plotters that the test epoch end
-        for plotter in self.test_plotters:
-            plotter.on_step_end(self, label="Test")
+            # Notify plotters that the test epoch end
+            for plotter in self.test_plotters:
+                plotter.on_step_end(self, label="Test")


### PR DESCRIPTION
The **--no_log** command line flag doesn't work: some plots are still drawn and an Exception is raised :

This PR ensures that when **-no_log** is specified all drawing and logging code is ignored.

```python
    wrapper_output = wrapper_module(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/parallel/distributed.py", line 1519, in forward
    else self._run_ddp_forward(*inputs, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/parallel/distributed.py", line 1355, in _run_ddp_forward
    return self.module(*inputs, **kwargs)  # type: ignore[index]
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/pytorch_lightning/strategies/strategy.py", line 633, in wrapped_forward
    out = method(*_args, **_kwargs)
  File "/home/guibertf/py4cast/py4cast/lightning.py", line 598, in validation_step
    plotter.update(self, prediction=prediction, target=target)
  File "/home/guibertf/py4cast/py4cast/observer.py", line 122, in update
    self.plot_map(
  File "/home/guibertf/py4cast/py4cast/observer.py", line 269, in plot_map
    dest_file.parent.mkdir(exist_ok=True)
  File "/opt/conda/lib/python3.10/pathlib.py", line 1175, in mkdir
    self._accessor.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/scratch/shared/py4cast/logs/camp0/dummy/unetrpp/guib_run_21/epoch_evol_per_param'
```