### PR TITLE
Improves NamedTensor and make ar loop more expressive and flexible

### DIFF
--- a/bin/gif_comparison.py
+++ b/bin/gif_comparison.py
@@ -31,7 +31,7 @@ from skimage.transform import resize
 from tqdm import trange
 
 from py4cast.datasets import get_datasets
-from py4cast.datasets.base import Item, collate_fn
+from py4cast.datasets.base import Item
 from py4cast.datasets.titan.settings import AROME_PATH, METADATA
 from py4cast.lightning import ArLightningHyperParam, AutoRegressiveLightning
 from py4cast.plots import DomainInfo
@@ -157,7 +157,7 @@ def get_item_for_date(date: str, hparams: ArLightningHyperParam) -> Item:
 
 def make_forecast(model: AutoRegressiveLightning, item: Item) -> torch.tensor:
     """Applies a model an Item to make a forecast."""
-    batch_item = collate_fn([item])
+    batch_item = item.unsqueeze_("batch", 0)
     preds = model(batch_item)
     forecast = preds.tensor
     # Here we reshape output from GNNS to be on the grid

--- a/bin/train.py
+++ b/bin/train.py
@@ -200,6 +200,13 @@ parser.add_argument(
     default=False,
     help="Use pin_memory in dataloader",
 )
+parser.add_argument(
+    "--channels_last",
+    "-cl",
+    action=BooleanOptionalAction,
+    default=False,
+    help="Use torch's channel last",
+)
 
 args, other = parser.parse_known_args()
 username = getpass.getuser()
@@ -279,6 +286,7 @@ hp = ArLightningHyperParam(
     use_lr_scheduler=args.use_lr_scheduler,
     precision=args.precision,
     no_log=args.no_log,
+    channels_last=args.channels_last,
 )
 
 # Logger & checkpoint callback

--- a/bin/train.py
+++ b/bin/train.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytorch_lightning as pl
 import torch
 from lightning.pytorch.loggers import TensorBoardLogger
-from lightning.pytorch.profilers import PyTorchProfiler
+from lightning.pytorch.profilers import AdvancedProfiler, PyTorchProfiler
 from lightning_fabric.utilities import seed
 from pytorch_lightning.callbacks import LearningRateMonitor
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
@@ -323,12 +323,18 @@ else:
 if args.profiler == "pytorch":
     profiler = PyTorchProfiler(
         dirpath=ROOTDIR / f"logs/{args.model}/{args.dataset}",
-        filename=f"profile_{run_id}",
+        filename=f"torch_profile_{run_id}",
         export_to_chrome=True,
         profile_memory=True,
     )
     print("Initiate pytorchProfiler")
-elif args.profiler in ("simple", "advanced"):
+elif args.profiler == "advanced":
+    profiler = AdvancedProfiler(
+        dirpath=ROOTDIR / f"logs/{args.model}/{args.dataset}",
+        filename=f"advanced_profile_{run_id}",
+        line_count_restriction=50,  # Display top 50 lines
+    )
+elif args.profiler == "simple":
     profiler = args.profiler
 else:
     profiler = None

--- a/bin/train.py
+++ b/bin/train.py
@@ -328,6 +328,8 @@ if args.profiler == "pytorch":
         profile_memory=True,
     )
     print("Initiate pytorchProfiler")
+elif args.profiler in ("simple", "advanced"):
+    profiler = args.profiler
 else:
     profiler = None
     print(f"No profiler set {args.profiler}")

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -68,8 +68,8 @@ class NamedTensor(TensorWrapper):
             )
         if tensor.shape[names.index(feature_dim_name)] != len(feature_names):
             raise ValueError(
-                f"Number of feature names ({len(feature_names)}:{feature_names}) must match"
-                f"number of features ({tensor.shape[names.index(feature_dim_name)]})"
+                f"Number of feature names ({len(feature_names)}:{feature_names}) must match "
+                f"number of features ({tensor.shape[names.index(feature_dim_name)]}) in the supplied tensor"
             )
 
         super().__init__(tensor)
@@ -275,7 +275,7 @@ class NamedTensor(TensorWrapper):
 
     def index_select_dim(
         self, dim_name: str, indices: torch.Tensor, bare_tensor: bool = True
-    ) -> torch.Tensor:
+    ) -> Union["NamedTensor", torch.Tensor]:
         """
         Return the tensor indexed along the dimension dim_name
         with the indices tensor.

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -189,12 +189,13 @@ class NamedTensor(TensorWrapper):
 
     def __getitem__(self, feature_name: str) -> torch.Tensor:
         """
-        Get one feature of the tensor by name.
+        Get one feature from the features dimension of the tensor by name.
+        The returned tensor has the same number of dimensions as the original tensor.
         """
         try:
-            return self.tensor[..., self.feature_names_to_idx[feature_name]].unsqueeze(
-                -1
-            )
+            return self.select_dim(
+                self.feature_dim_name, self.feature_names_to_idx[feature_name]
+            ).unsqueeze(self.names.index(self.feature_dim_name))
         except KeyError:
             raise ValueError(
                 f"Feature {feature_name} not found in {self.feature_names}"

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -261,6 +261,7 @@ class NamedTensor(TensorWrapper):
         Return the tensor indexed along the dimension dim_name
         with the index index.
         The given dimension is removed from the tensor.
+        See https://pytorch.org/docs/stable/generated/torch.select.html
         """
         if bare_tensor:
             return self.tensor.select(self.names.index(dim_name), index)
@@ -283,6 +284,7 @@ class NamedTensor(TensorWrapper):
         The returned tensor has the same number of dimensions as the original tensor (input).
         The dimth dimension has the same size as the length of index; other dimensions have
         the same size as in the original tensor.
+        See https://pytorch.org/docs/stable/generated/torch.index_select.html
         """
         if bare_tensor:
             return self.tensor.index_select(

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -374,6 +374,12 @@ class NamedTensor(TensorWrapper):
         """
         self.tensor = self.tensor.pin_memory()
 
+    def to_(self, *args, **kwargs):
+        """
+        'In place' operation to call torch's 'to' method on the underlying tensor.
+        """
+        self.tensor = self.tensor.to(*args, **kwargs)
+
 
 @dataclass(slots=True)
 class Item:
@@ -404,6 +410,14 @@ class Item:
         self.inputs.squeeze_(dim_name)
         self.outputs.squeeze_(dim_name)
         self.forcing.squeeze_(dim_name)
+
+    def to_(self, *args, **kwargs):
+        """
+        'In place' operation to call torch's 'to' method on the underlying NamedTensors.
+        """
+        self.inputs.to_(*args, **kwargs)
+        self.outputs.to_(*args, **kwargs)
+        self.forcing.to_(*args, **kwargs)
 
     def pin_memory(self):
         """

--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -56,16 +56,20 @@ class NamedTensor(TensorWrapper):
     SPATIAL_DIM_NAMES = ("lat", "lon", "ngrid")
 
     def __init__(
-        self, tensor: torch.Tensor, names: List[str], feature_names: List[str]
+        self,
+        tensor: torch.Tensor,
+        names: List[str],
+        feature_names: List[str],
+        feature_dim_name: str = "features",
     ):
         if len(tensor.shape) != len(names):
             raise ValueError(
                 f"Number of names ({len(names)}) must match number of dimensions ({len(tensor.shape)})"
             )
-        if tensor.shape[-1] != len(feature_names):
+        if tensor.shape[names.index(feature_dim_name)] != len(feature_names):
             raise ValueError(
                 f"Number of feature names ({len(feature_names)}:{feature_names}) must match"
-                f"number of features ({tensor.shape[-1]})"
+                f"number of features ({tensor.shape[names.index(feature_dim_name)]})"
             )
 
         super().__init__(tensor)
@@ -76,6 +80,7 @@ class NamedTensor(TensorWrapper):
             feature_name: idx for idx, feature_name in enumerate(feature_names)
         }
         self.feature_names = feature_names
+        self.feature_dim_name = feature_dim_name
 
     @property
     def ndims(self):
@@ -169,6 +174,12 @@ class NamedTensor(TensorWrapper):
                 list(chain.from_iterable(nt.feature_names for nt in nts)),
             )
 
+    def dim_index(self, dim_name: str) -> int:
+        """
+        Return the index of a dimension given its name.
+        """
+        return self.names.index(dim_name)
+
     def clone(self):
         return NamedTensor(
             tensor=deepcopy(self.tensor).to(self.tensor.device),
@@ -223,6 +234,69 @@ class NamedTensor(TensorWrapper):
         self.tensor = self.tensor.unflatten(dim, unflattened_size)
         self.names = self.names[:dim] + [*unflatten_dim_name] + self.names[dim + 1 :]
 
+    def squeeze_(self, dim_name: Union[List[str], str]):
+        """
+        Squeeze the underlying tensor along the dimension(s)
+        given its/their name(s).
+        """
+        if isinstance(dim_name, str):
+            dim_name = [dim_name]
+        dim_indices = [self.names.index(name) for name in dim_name]
+        self.tensor = torch.squeeze(self.tensor, dim=dim_indices)
+        for name in dim_name:
+            self.names.remove(name)
+
+    def unsqueeze_(self, dim_name: str, dim_index: int):
+        """ "
+        Insert a new dimension dim_name at dim_index of size 1
+        """
+        self.tensor = torch.unsqueeze(self.tensor, dim_index)
+        self.names.insert(dim_index, dim_name)
+
+    def select_dim(
+        self, dim_name: str, index: int, bare_tensor: bool = True
+    ) -> Union["NamedTensor", torch.Tensor]:
+        """
+        Return the tensor indexed along the dimension dim_name
+        with the index index.
+        The given dimension is removed from the tensor.
+        """
+        if bare_tensor:
+            return self.tensor.select(self.names.index(dim_name), index)
+        else:
+            # if they try to select the features it will break as
+            # the feature dimension is not present anymore
+            return NamedTensor(
+                self.select_dim(dim_name, index, bare_tensor=True),
+                self.names[: self.names.index(dim_name)]
+                + self.names[self.names.index(dim_name) + 1 :],
+                self.feature_names,
+            )
+
+    def index_select_dim(
+        self, dim_name: str, indices: torch.Tensor, bare_tensor: bool = True
+    ) -> torch.Tensor:
+        """
+        Return the tensor indexed along the dimension dim_name
+        with the indices tensor.
+        The returned tensor has the same number of dimensions as the original tensor (input).
+        The dimth dimension has the same size as the length of index; other dimensions have
+        the same size as in the original tensor.
+        """
+        if bare_tensor:
+            return self.tensor.index_select(
+                self.names.index(dim_name),
+                torch.Tensor(indices).type(torch.int64).to(self.device),
+            )
+        else:
+            return NamedTensor(
+                self.index_select_dim(dim_name, indices, bare_tensor=True),
+                self.names,
+                self.feature_names
+                if dim_name != self.feature_dim_name
+                else [self.feature_names[i] for i in indices],
+            )
+
     def dim_size(self, dim_name: str) -> int:
         """
         Return the size of a dimension given its name.
@@ -232,7 +306,7 @@ class NamedTensor(TensorWrapper):
         except ValueError as ve:
             raise ValueError(f"Dimension {dim_name} not found in {self.names}") from ve
 
-    @cached_property
+    @property
     def spatial_dim_idx(self) -> List[int]:
         """
         Return the indices of the spatial dimensions in the tensor.
@@ -312,6 +386,23 @@ class Item:
     inputs: NamedTensor
     forcing: NamedTensor
     outputs: NamedTensor
+
+    def unsqueeze_(self, dim_name: str, dim_index: int):
+        """
+        Insert a new dimension dim_name at dim_index of size 1
+        """
+        self.inputs.unsqueeze_(dim_name, dim_index)
+        self.outputs.unsqueeze_(dim_name, dim_index)
+        self.forcing.unsqueeze_(dim_name, dim_index)
+
+    def squeeze_(self, dim_name: Union[List[str], str]):
+        """
+        Squeeze the underlying tensor along the dimension(s)
+        given its/their name(s).
+        """
+        self.inputs.squeeze_(dim_name)
+        self.outputs.squeeze_(dim_name)
+        self.forcing.squeeze_(dim_name)
 
     def pin_memory(self):
         """

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -454,10 +454,10 @@ class AutoRegressiveLightning(pl.LightningModule):
                         dim=timestep_dim_index,
                     )
 
-                    # Make a new NamedTensor with the new state with the same dimensions
-                    # and features as the inputs
+                    # Make a new NamedTensor with the same dim and
+                    # feature names as the original prev_states
                     prev_states = NamedTensor.new_like(
-                        new_prev_states_tensor, batch.inputs
+                        new_prev_states_tensor, prev_states
                     )
             # Append prediction to prediction list only "normal steps"
             prediction_list.append(new_state)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -56,6 +56,7 @@ def test_named_tensor():
         torch.rand(3, 256, 256, 50),
         names=["batch", "lat", "lon", "levels"],
         feature_names=[f"feature_{i}" for i in range(50)],
+        feature_dim_name="levels",
     )
     assert nt4.spatial_dim_idx == [1, 2]
     with pytest.raises(ValueError):
@@ -66,9 +67,18 @@ def test_named_tensor():
         torch.rand(3, 256, 50),
         names=["batch", "lat", "lon"],
         feature_names=[f"feature_{i}" for i in range(50)],
+        feature_dim_name="lon",
     )
     with pytest.raises(ValueError):
         nt | nt5
+
+    with pytest.raises(ValueError):
+        # missing feature_dim_name
+        nt = NamedTensor(
+            torch.rand(3, 256, 256, 50),
+            names=["batch", "lat", "lon", "tutu"],
+            feature_names=[f"feature_{i}" for i in range(49)],
+        )
 
     # missing feature with __getitem__ lookup => ValueError
     with pytest.raises(ValueError):
@@ -136,6 +146,48 @@ def test_named_tensor():
         f"v_{i}" for i in range(10)
     ] + [f"u_{i}" for i in range(10)]
     assert nt_cat.names == ["batch", "lat", "lon", "features"]
+
+    # test unsqueeze_
+    nt_cat.unsqueeze_("new_dim", 1)
+    assert nt_cat.tensor.shape == (3, 1, 256, 256, 30)
+    assert nt_cat.names == ["batch", "new_dim", "lat", "lon", "features"]
+
+    # test squeeze_
+    nt_cat.squeeze_("new_dim")
+    assert nt_cat.tensor.shape == (3, 256, 256, 30)
+    assert nt_cat.names == ["batch", "lat", "lon", "features"]
+
+    # test select_dim along the features dim
+    t = nt_cat.select_dim("features", 0)
+    assert t.shape == (3, 256, 256)
+
+    # test select_dim along the lat dim
+    t = nt_cat.select_dim("lat", 128)
+    assert t.shape == (3, 256, 30)
+
+    # test index_select_dim
+    t = nt_cat.index_select_dim("features", [0, 1, 2])
+    assert t.shape == (3, 256, 256, 3)
+
+    # test select_dim when returning NamedTensor
+    with pytest.raises(ValueError):
+        t = nt_cat.select_dim("features", 0, bare_tensor=False)
+    t = nt_cat.select_dim("lon", 0, bare_tensor=False)
+    assert t.tensor.shape == (3, 256, 30)
+    assert t.feature_names == nt_cat.feature_names
+    assert t.names == ["batch", "lat", "features"]
+
+    # test index_select_dim when returning NamedTensor
+    t = nt_cat.index_select_dim("features", [0, 1, 2], bare_tensor=False)
+    assert t.tensor.shape == (3, 256, 256, 3)
+    assert t.feature_names == nt_cat.feature_names[:3]
+    assert t.names == ["batch", "lat", "lon", "features"]
+
+    # test dim_size
+    assert nt_cat.dim_size("features") == 30
+
+    # test dim_index
+    assert nt_cat.dim_index("features") == 3
 
 
 def test_item():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -189,6 +189,18 @@ def test_named_tensor():
     # test dim_index
     assert nt_cat.dim_index("features") == 3
 
+    # test NamedTensor with features in second dim
+    nt = NamedTensor(
+        torch.rand(3, 50, 256, 256),
+        names=["batch", "features", "lat", "lon"],
+        feature_names=[f"feature_{i}" for i in range(50)],
+    )
+    assert nt.dim_size("features") == 50
+    assert nt.dim_index("features") == 1
+    # test __getitem__ with feature name
+    f = nt["feature_0"]
+    assert f.shape == (3, 1, 256, 256)
+
 
 def test_item():
     """


### PR DESCRIPTION
* Improves NamedTensor with index_select_dim and select_dim which maps to underlying torch's index_select and select
* NamedTensor now accept any dimension as the "special" features dimension (constructor argument with a default value of "features"). __getitem__ uses the right dimension
* Added unit tests for new NamedTensor features
* lightning auto-regressive loop is now more explicit and flexible, timestep dim and tensor slicing is no longer hardcoded
* Adds channels_last option (default False)
* Restores simple and advanced profiling options

The advanced profiling saved to a local text file does the job:
![image](https://github.com/user-attachments/assets/de13eeec-710b-4d30-ae4d-7b8945d43fec)
