### PR TITLE
Add a log file with git commit and status when launching training

### DIFF
--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -1,5 +1,6 @@
 import getpass
 import shutil
+import subprocess
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from functools import cached_property
@@ -256,6 +257,19 @@ class AutoRegressiveLightning(pl.LightningModule):
                 shutil.copyfile(
                     hparams.model_conf, hparams.save_path / "model_conf.json"
                 )
+            # Write commit and state of git repo in log file
+            dest_git_log = hparams.save_path / "git_log.txt"
+            out_log = (
+                subprocess.check_output(["git", "log", "-n", "1"])
+                .strip()
+                .decode("utf-8")
+            )
+            out_status = (
+                subprocess.check_output(["git", "status"]).strip().decode("utf-8")
+            )
+            with open(dest_git_log, "w") as f:
+                f.write(out_log)
+                f.write(out_status)
 
     def on_fit_start(self):
         self.log_hparams_tb()

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -1,6 +1,5 @@
 import getpass
 import shutil
-import subprocess
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from functools import cached_property
@@ -257,19 +256,6 @@ class AutoRegressiveLightning(pl.LightningModule):
                 shutil.copyfile(
                     hparams.model_conf, hparams.save_path / "model_conf.json"
                 )
-            # Write commit and state of git repo in log file
-            dest_git_log = hparams.save_path / "git_log.txt"
-            out_log = (
-                subprocess.check_output(["git", "log", "-n", "1"])
-                .strip()
-                .decode("utf-8")
-            )
-            out_status = (
-                subprocess.check_output(["git", "status"]).strip().decode("utf-8")
-            )
-            with open(dest_git_log, "w") as f:
-                f.write(out_log)
-                f.write(out_status)
 
     def on_fit_start(self):
         self.log_hparams_tb()


### PR DESCRIPTION
- Add a log file in the same folder as training logs, named `git_log.txt`, which contains info on the last commit and the git status.

Example:
```bash
commit 6f1e238692f6c6651675f4a8da93218c9bfd96ab
Author: colon3ltocard <36170699+colon3ltocard@users.noreply.github.com>
Date:   Thu Oct 3 10:04:23 2024 +0200

    prevent shutils.copy in no_log mode (#57)On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   py4cast/lightning.py

no changes added to commit (use "git add" and
```