### PR TITLE
preserves feature_dim_name

### DIFF
--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -273,6 +273,7 @@ class NamedTensor(TensorWrapper):
                 self.names[: self.names.index(dim_name)]
                 + self.names[self.names.index(dim_name) + 1 :],
                 self.feature_names,
+                feature_dim_name=self.feature_dim_name,
             )
 
     def index_select_dim(
@@ -298,6 +299,7 @@ class NamedTensor(TensorWrapper):
                 self.feature_names
                 if dim_name != self.feature_dim_name
                 else [self.feature_names[i] for i in indices],
+                feature_dim_name=self.feature_dim_name,
             )
 
     def dim_size(self, dim_name: str) -> int:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -201,6 +201,18 @@ def test_named_tensor():
     f = nt["feature_0"]
     assert f.shape == (3, 1, 256, 256)
 
+    # test feature_dim_name is preserved by select_dim and index_select_dim
+    nt = NamedTensor(
+        torch.rand(3, 50, 256, 256),
+        names=["batch", "feats", "lat", "lon"],
+        feature_names=[f"feature_{i}" for i in range(50)],
+        feature_dim_name="feats",
+    )
+    t = nt.select_dim("batch", 0, bare_tensor=False)
+    assert t.feature_dim_name == "feats"
+    t = nt.index_select_dim("feats", [0, 1, 2], bare_tensor=False)
+    assert t.feature_dim_name == "feats"
+
 
 def test_item():
     """


### PR DESCRIPTION
* when returning NamedTensor the select_dim and index_select_dim were not preserving the feature dimension attribute, this PR fixes that.