### PR TITLE
create config to consider arpege data for lbc

### DIFF
--- a/config/datasets/titan_lbc.json
+++ b/config/datasets/titan_lbc.json
@@ -1,0 +1,87 @@
+{
+    "periods": {
+        "train": {
+            "start": 2021010103,
+            "end": 2022123123,
+            "step": 1
+        },
+        "valid": {
+            "start": 2023010103,
+            "end": 2023123123,
+            "step": 3
+        },
+        "test": {
+            "start": 2023010103,
+            "end": 2023123123,
+            "step": 3
+        }
+    },
+    "grid":{
+        "name": "PAAROME_1S40",
+        "border_size": 0,
+        "subdomain": [100, 612, 240, 880]
+    },
+    "settings":{
+        "step_duration": 1,
+        "standardize": true,
+        "file_format": "npy"
+    },
+    "params": {
+        "aro_t2m": {
+            "levels": [2],
+            "kind": "input_output"
+        },
+        "aro_r2": {
+            "levels": [2],
+            "kind": "input_output"
+        },
+        "aro_tp": {
+            "levels": [0],
+            "kind": "input_output"
+        },
+        "aro_u10": {
+            "levels": [10],
+            "kind": "input_output"
+        },
+        "aro_v10": {
+            "levels": [10],
+            "kind": "input_output"
+        },
+        "aro_t": {
+            "levels": [250, 500, 700, 850],
+            "kind": "input_output"
+        },
+        "aro_u": {
+            "levels": [250, 500, 700, 850],
+            "kind": "input_output"
+        },
+        "aro_v": {
+            "levels": [250, 500, 700, 850],
+            "kind": "input_output"
+        },
+        "aro_z": {
+            "levels": [250, 500, 700, 850],
+            "kind": "input_output"
+        },
+        "arp_t": {
+            "levels": [250, 500, 700, 850],
+            "kind": "input"
+        },
+        "arp_u":{
+            "levels": [250, 500, 700, 850],
+            "kind": "input"
+        },
+        "arp_v":{
+            "levels": [250, 500, 700, 850],
+            "kind": "input"
+        },
+        "arp_z":{
+            "levels": [250, 500, 700, 850],
+            "kind": "input"
+        },
+        "arp_r":{
+            "levels": [250, 500, 700, 850],
+            "kind": "input"
+        }
+    }
+}

--- a/py4cast/datasets/titan/__init__.py
+++ b/py4cast/datasets/titan/__init__.py
@@ -203,9 +203,9 @@ class Param:
             self.level_type = "hPa"
         self.long_name = param_info["long_name"]
         self.native_grid = param_info["grid"]
-        if self.native_grid not in ["PAAROME_1S100", "PAAROME_1S40"]:
+        if self.native_grid not in ["PAAROME_1S100", "PAAROME_1S40", "PA_01D"]:
             raise NotImplementedError(
-                "Parameter native grid must be in ['PAAROME_1S100', 'PAAROME_1S40']"
+                "Parameter native grid must be in ['PAAROME_1S100', 'PAAROME_1S40', 'PA_01D']"
             )
 
     @property


### PR DESCRIPTION
Adding Arpege data to Titan dataset for boundary forcing.

To do that, I will follow those steps :
- Selecting the desired atmespheric parameters, for instance u, v, t, z and hu at levels 250, 500, 700 and 850. Those are defined in the configuration file (titan_lbc.json).
- Converting grib data to npy format.
- Resizing and resampling Arpege data to the Titan dataset size and resolution (Arome 2km, 512 x 640) 