### PR TITLE
Restores encoder proj_sizes as per original paper + associated settings

### DIFF
--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -640,7 +640,9 @@ class UNETRPP(ModelABC, nn.Module):
         self.hidden_size = settings.hidden_size
         self.spatial_dims = settings.spatial_dims
         # Number of pixels after stem layer
-        no_pixels = (input_shape[0] * input_shape[1]) // (settings.downsampling_rate**2)
+        no_pixels = (input_shape[0] * input_shape[1]) // (
+            settings.downsampling_rate**2
+        )
         encoder_input_size = [
             no_pixels,
             no_pixels // 4,


### PR DESCRIPTION
* in a previous PR I added proj_size as a setting and it was applied to all EPA modules accross the UnetR++ architectures
* I see a slight (0.4) increase in val_loss following this modification, but spectral RMSE are almost identical
* This PR reverts the proj_sizes as per the original implementation and adds dedicated settings for decoder_proj_size (32) and encoder_proj_sizes (64, 64, 64, 32)