### PR TITLE
Fixes flash_attn + cascade attention_code to decoder Transformer bloc…

### DIFF
--- a/Dockerfile.ewc_flash_attn
+++ b/Dockerfile.ewc_flash_attn
@@ -1,0 +1,55 @@
+FROM pytorch/pytorch:2.1.2-cuda11.8-cudnn8-devel
+
+ARG INJECT_MF_CERT
+
+COPY mf.crt /usr/local/share/ca-certificates/mf.crt
+
+# The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
+RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
+# set apt to non interactive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MY_APT='apt -o "Acquire::https::Verify-Peer=false" -o "Acquire::AllowInsecureRepositories=true" -o "Acquire::AllowDowngradeToInsecureRepositories=true" -o "Acquire::https::Verify-Host=false"'
+
+RUN $MY_APT update && $MY_APT install -y software-properties-common && add-apt-repository ppa:ubuntugis/ppa
+RUN $MY_APT update && $MY_APT install -y curl gdal-bin libgdal-dev libgeos-dev git vim nano sudo libx11-dev tk python3-tk tk-dev libpng-dev libffi-dev dvipng texlive-latex-base texlive-latex-extra  texlive-fonts-recommended cm-super openssh-server netcat libeccodes-dev libeccodes-tools openssh-server
+
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
+ENV C_INCLUDE_PATH=/usr/include/gdal
+
+ARG REQUESTS_CA_BUNDLE
+ARG CURL_CA_BUNDLE
+
+# Build eccodes, a recent version yields far better throughput according to our benchmarks
+ARG ECCODES_VER=2.35.0
+RUN curl -O https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$ECCODES_VER-Source.tar.gz && tar -xzf eccodes-$ECCODES_VER-Source.tar.gz && mkdir build && cd build && cmake ../eccodes-$ECCODES_VER-Source -DENABLE_AEC=ON -DENABLE_NETCDF=ON -DENABLE_FORTRAN=OFF && make && ctest && make install && ldconfig
+
+RUN pip install --upgrade pip
+COPY requirements.txt /root/requirements.txt
+RUN set -eux && pip install --default-timeout=100 -r /root/requirements.txt
+RUN MAX_JOBS=8 pip install flash-attn --no-build-isolation
+ARG USERNAME
+ARG GROUPNAME
+ARG USER_UID
+ARG USER_GUID
+ARG HOME_DIR
+ARG NODE_EXTRA_CA_CERTS
+
+RUN set -eux && groupadd --gid $USER_GUID $GROUPNAME \
+    # https://stackoverflow.com/questions/73208471/docker-build-issue-stuck-at-exporting-layers
+    && mkdir -p $HOME_DIR && useradd -l --uid $USER_UID --gid $USER_GUID -s /bin/bash --home-dir $HOME_DIR --create-home $USERNAME \
+    && chown $USERNAME:$GROUPNAME $HOME_DIR \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && echo "$USERNAME:$USERNAME" | chpasswd \
+    && mkdir /run/sshd
+
+RUN set -eux && pip install pyg-lib==0.4.0 torch-scatter==2.1.2 torch-sparse==0.6.18 torch-cluster==1.6.2\
+    torch-geometric==2.3.1 -f https://data.pyg.org/whl/torch-2.1.2+cpu.html
+
+WORKDIR $HOME_DIR
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+
+
+
+

--- a/config/models/unetrpp161024_linear_up.json
+++ b/config/models/unetrpp161024_linear_up.json
@@ -1,5 +1,5 @@
 {
-"num_heads": 16,
+"num_heads_encoder": 16,
 "hidden_size": 1024,
 "linear_upsampling": true
 }

--- a/config/models/unetrpp161024_linear_up_flash.json
+++ b/config/models/unetrpp161024_linear_up_flash.json
@@ -1,0 +1,7 @@
+{
+"num_heads_encoder": 16,
+"hidden_size": 1024,
+"linear_upsampling": true,
+"attention_code": "flash"
+}
+

--- a/config/models/unetrpp8512.json
+++ b/config/models/unetrpp8512.json
@@ -1,5 +1,5 @@
 {
-"num_heads": 8,
+"num_heads_encoder": 8,
 "hidden_size": 512
 }
 

--- a/config/models/unetrpp8512_linear_up.json
+++ b/config/models/unetrpp8512_linear_up.json
@@ -1,5 +1,5 @@
 {
-"num_heads": 8,
+"num_heads_encoder": 8,
 "hidden_size": 512,
 "linear_upsampling": true
 }

--- a/config/models/unetrpp8512_linear_up_d2.json
+++ b/config/models/unetrpp8512_linear_up_d2.json
@@ -1,5 +1,5 @@
 {
-"num_heads": 8,
+"num_heads_encoder": 8,
 "hidden_size": 512,
 "linear_upsampling": true,
 "downsampling_rate": 2

--- a/doc/installEWC.md
+++ b/doc/installEWC.md
@@ -1,0 +1,16 @@
+## Installation instruction on EWC ECMWF A100 machines
+
+This procedure uses MF's docker wrapper runai and assumes it is available on your PATH and that docker has been installed on your machine.
+
+```bash
+export RUNAI_DOCKER_FILENAME=Dockerfile.ewc_flash_attn
+runai build
+```
+
+You should now be able to run a test training with the Dummy dataset using flash_attnand bf16 precision:
+
+```bash
+ runai exec_gpu python bin/train.py --dataset dummy --model unetrpp --epochs 1  --batch_size 2 --model_conf config/models/unetrpp161024_linear_up_flash.json --precision bf16
+ ```
+ 
+

--- a/doc/installEWC.md
+++ b/doc/installEWC.md
@@ -7,7 +7,7 @@ export RUNAI_DOCKER_FILENAME=Dockerfile.ewc_flash_attn
 runai build
 ```
 
-You should now be able to run a test training with the Dummy dataset using flash_attnand bf16 precision:
+You should now be able to run a test training with the Dummy dataset using flash_attn and bf16 precision:
 
 ```bash
  runai exec_gpu python bin/train.py --dataset dummy --model unetrpp --epochs 1  --batch_size 2 --model_conf config/models/unetrpp161024_linear_up_flash.json --precision bf16

--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -300,7 +300,6 @@ class EPA(nn.Module):
         k_shared = torch.nn.functional.normalize(k_shared, dim=-1).type_as(k_shared)
         if self.use_scaled_dot_product_CA:
             if self.attention_code == "torch":
-                # print(q_shared.shape)
                 x_CA = self.attn_func(
                     q_shared, k_shared, v_CA, dropout_p=self.attn_drop.p
                 )

--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -305,7 +305,8 @@ class EPA(nn.Module):
                 )
             elif self.attention_code == "flash":
                 # flash attention expects inputs of shape (batch_size, seqlen, nheads, headdim)
-                # so we need to permute the dimensions from (batch, head, channels, spatial_dim) to (batch, channels, head, spatial_dim)
+                # so we need to permute the dimensions from (batch, head, channels, spatial_dim) 
+                # to (batch, channels, head, spatial_dim)
                 q_shared = q_shared.permute(0, 2, 1, 3)
                 k_shared = k_shared.permute(0, 2, 1, 3)
                 v_CA = v_CA.permute(0, 2, 1, 3)

--- a/py4cast/models/vision/unetrpp.py
+++ b/py4cast/models/vision/unetrpp.py
@@ -305,7 +305,7 @@ class EPA(nn.Module):
                 )
             elif self.attention_code == "flash":
                 # flash attention expects inputs of shape (batch_size, seqlen, nheads, headdim)
-                # so we need to permute the dimensions from (batch, head, channels, spatial_dim) 
+                # so we need to permute the dimensions from (batch, head, channels, spatial_dim)
                 # to (batch, channels, head, spatial_dim)
                 q_shared = q_shared.permute(0, 2, 1, 3)
                 k_shared = k_shared.permute(0, 2, 1, 3)

--- a/reformat.sh
+++ b/reformat.sh
@@ -4,5 +4,5 @@ set -eux
 
 id
 pwd
-isort --profile black $1
-black $1
+python -m isort --profile black $1
+python -m black $1


### PR DESCRIPTION
* Cascade attention_code to decoder Transformer block (wasn't the case !)
* fixes flash_attn dim ordering (It still won't work on grib > 64x64 due to the way the unetrpp splits attention heads accross channels and not flattened physical (pixels, voxels) dims
* adds num_heads_decoder to allow changing the number of attention heads in the decoder
* adds a Dockerfile to work on EWC with A100 and flash_attn, we need an older cuda version, added doc for that