### PR TITLE
fix bug : config_file type str -> Path

### DIFF
--- a/py4cast/datasets/__init__.py
+++ b/py4cast/datasets/__init__.py
@@ -73,7 +73,7 @@ def get_datasets(
     num_input_steps: int,
     num_pred_steps_train: int,
     num_pred_steps_val_test: int,
-    config_file: Union[Path, None] = None,
+    config_file: Union[str, None] = None,
     config_override: Union[Dict, None] = None,
 ) -> Tuple[DatasetABC, DatasetABC, DatasetABC]:
     """

--- a/py4cast/datasets/__init__.py
+++ b/py4cast/datasets/__init__.py
@@ -89,7 +89,7 @@ def get_datasets(
             f"Dataset {name} not found in registry, available datasets are :{registry.keys()}"
         ) from ke
 
-    config_file = default_config if config_file is None else config_file
+    config_file = default_config if config_file is None else Path(config_file)
 
     return dataset_kls.from_json(
         config_file,


### PR DESCRIPTION
Fix bug for Titan inference. 
Cast config_file as a Path instead of a str as intended for from_json argument.
Command:
python bin/inference.py --model_path /scratch/shared/py4cast/logs/camp0/titan/halfunet/sezn_run_dev_41 --date 2023010300 --dataset titan --infer_steps 2

Stack trace:
Traceback (most recent call last):
  File "/home/mrmn/seznecc/repository/py4cast/bin/inference.py", line 71, in <module>
    dm = PlDataModule(
  File "<string>", line 10, in __init__
  File "/home/mrmn/seznecc/repository/py4cast/py4cast/lightning.py", line 63, in __post_init__
    self.train_ds, self.val_ds, self.test_ds = get_datasets(
  File "/home/mrmn/seznecc/repository/py4cast/py4cast/datasets/__init__.py", line 95, in get_datasets
    return dataset_kls.from_json(
  File "/home/mrmn/seznecc/repository/py4cast/py4cast/datasets/titan/__init__.py", line 699, in from_json
    fname.stem,
AttributeError: 'str' object has no attribute 'stem