### PR TITLE
Add script to compare RSME of multiple models

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ You can find more details about all the `num_X_steps` options [here](doc/num_ste
 Inference is done by running the `bin/inference.py` script. This script will load a model and run it on a dataset using the training parameters (dataset config, timestep options, ...).
 
 ```bash
-usage: py4cast Inference script [-h] [--model_path MODEL_PATH] [--dataset DATASET] [--infer_steps INFER_STEPS] [--date DATE]
+usage: python bin/inference.py [-h] [--model_path MODEL_PATH] [--dataset DATASET] [--infer_steps INFER_STEPS] [--date DATE]
 
 options:
   -h, --help            show this help message and exit
@@ -511,7 +511,7 @@ A simple example of inference is shown below:
 You can compare multiple trained models on specific case studies and visualize the forecasts on animated plots with the `bin/gif_comparison.py`. See example of GIF at the beginning of the README.
 
 Warnings:
- - For now this script only works with models trained with Titan dataset.
+- For now this script only works with models trained with Titan dataset.
 - If you want to use AROME as a model, you have to manually download the forecast before.
 
 ```bash
@@ -527,6 +527,22 @@ options:
 example: python bin/gif_comparison.py --ckpt AROME --ckpt /.../logs/my_run/epoch=247.ckpt
                                       --date 2023061812 --num_pred_steps 10
 ```
+
+### Scoring and comparing models
+
+The `bin/test.py` script will compute and save metrics on the validation set, on as many auto-regressive prediction steps as you want.
+
+```bash
+python bin/test.py PATH_TO_CHECKPOINT --num_pred_steps 24
+```
+
+Once you have executed the `test.py` script on all the models you want, you can compare them with `bin/scores_comparison.py`:
+
+```bash
+python bin/scores_comparison.py --ckpt PATH_TO_CKPT_0  --ckpt PATH_TO_CKPT_1
+```
+
+**Warning**: For now `bin/scores_comparison.py` only works with models trained with Titan dataset
 
 ## Adding features and contributing
 

--- a/bin/gif_comparison.py
+++ b/bin/gif_comparison.py
@@ -288,7 +288,8 @@ def make_gif(
             models_names,
         )
         frames.append(frame)
-    gif.save(frames, f"{date}_{feature}.gif", duration=500)
+    filename = f"{date.strftime('%Y-%m-%d_%Hh%M')}_{feature}.gif"
+    gif.save(frames, filename, duration=500)
 
 
 if __name__ == "__main__":

--- a/bin/scores_comparison.py
+++ b/bin/scores_comparison.py
@@ -42,8 +42,7 @@ def plot_scores(features: List[str], data: dict, max_timestep: int = 12) -> None
         figsize = (4 * cols, 5 * lines)
 
     fig = plt.figure(constrained_layout=True, figsize=figsize, dpi=200)
-    axes = fig.subplots(nrows=lines, ncols=cols)
-    axs = axes.flat
+    axs = fig.subplots(nrows=lines, ncols=cols).flat
 
     for i, feature in enumerate(features):
         max_rmse = 0
@@ -70,7 +69,7 @@ if __name__ == "__main__":
     parser = ArgumentParser("Plot animations")
     parser.add_argument(
         "--ckpt",
-        type=str,
+        type=Path,
         action="append",
         help="Paths to the AI model checkpoint",
         required=True,
@@ -86,10 +85,9 @@ if __name__ == "__main__":
     scores = {}
     models_names = []
     for ckpt in args.ckpt:
-        path = Path(ckpt)
-        with open(path.parent / "Test_rmse_scores.json", "r") as json_file:
+        with open(ckpt.parent / "Test_rmse_scores.json", "r") as json_file:
             loaded_data = json.load(json_file)
-        model_name = f"{path.parent.name}"
+        model_name = f"{ckpt.parent.name}"
         scores[model_name] = loaded_data
 
     plot_scores(

--- a/bin/scores_comparison.py
+++ b/bin/scores_comparison.py
@@ -27,7 +27,7 @@ from py4cast.datasets.titan.settings import METADATA
 
 
 def plot_scores(features: List[str], data: dict, max_timestep: int = 12) -> None:
-    """Plots one frame of the animation."""
+    """Plots one graph per feature comparing RMSE of multiple models."""
 
     lines = int(math.sqrt(len(features)))
     cols = len(features) // lines
@@ -66,7 +66,7 @@ def plot_scores(features: List[str], data: dict, max_timestep: int = 12) -> None
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser("Plot animations")
+    parser = ArgumentParser("Plot RMSE")
     parser.add_argument(
         "--ckpt",
         type=Path,

--- a/bin/scores_comparison.py
+++ b/bin/scores_comparison.py
@@ -1,0 +1,82 @@
+import json
+import math
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+
+from py4cast.datasets.titan.settings import METADATA
+
+
+def plot_scores(features: List[str], data: dict, max_timestep: int = 12) -> None:
+    """Plots one frame of the animation."""
+
+    lines = int(math.sqrt(len(features)))
+    cols = len(features) // lines
+    if len(features) % lines != 0:
+        cols += 1
+
+    if (lines, cols) == (1, 3):
+        figsize = (12, 5)
+    elif (lines, cols) == (2, 2):
+        figsize = (4 * cols, 4 * lines)
+    else:
+        figsize = (4 * cols, 5 * lines)
+
+    fig = plt.figure(constrained_layout=True, figsize=figsize, dpi=200)
+    axes = fig.subplots(nrows=lines, ncols=cols)
+    axs = axes.flat
+
+    for i, feature in enumerate(features):
+        max_rmse = 0
+        for model in data.keys():
+            values = data[model][feature][:max_timestep]
+            if max(values) > max_rmse:
+                max_rmse = max(values)
+            axs[i].plot(range(1, len(values) + 1), values, label=model)
+            feature_name = "_".join(feature.split("_")[:2])
+            name = METADATA["WEATHER_PARAMS"][feature_name]["long_name"]
+            axs[i].set_title(name)
+            axs[i].set_ylim(bottom=0, top=max_rmse)
+            axs[i].set_xlabel("Leadtime (h)")
+            if i == 0:
+                axs[i].legend()
+
+    fig.suptitle("RMSE on Test set per leadtime")
+    copyright = "Météo-France, Py4cast project."
+    fig.text(0.4, 0.01, copyright, fontsize=8, ha="left")
+    plt.savefig("rmse_scores.png")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser("Plot animations")
+    parser.add_argument(
+        "--ckpt",
+        type=str,
+        action="append",
+        help="Paths to the AI model checkpoint",
+        required=True,
+    )
+    parser.add_argument(
+        "--num_pred_steps",
+        type=int,
+        default=12,
+        help="Number of auto-regressive steps/prediction steps.",
+    )
+    args = parser.parse_args()
+
+    scores = {}
+    models_names = []
+    for ckpt in args.ckpt:
+        path = Path(ckpt)
+        with open(path.parent / "Test_rmse_scores.json", "r") as json_file:
+            loaded_data = json.load(json_file)
+        model_name = f"{path.parent.name}"
+        scores[model_name] = loaded_data
+
+    plot_scores(
+        ["aro_t2m_2m", "aro_tp_0m", "aro_r2_2m", "aro_u10_10m"],
+        scores,
+        args.num_pred_steps,
+    )

--- a/bin/scores_comparison.py
+++ b/bin/scores_comparison.py
@@ -1,3 +1,20 @@
+"""Plots graphs comparing RMSE of multiple models on 4 surface features.
+Warnings - For now this script only works with models trained with Titan dataset.
+         - You must have launched the test.py script on each model you want to compare
+
+usage: scores_comparison.py [-h] --ckpt CKPT [--num_pred_steps NUM_PRED_STEPS]
+
+options:
+  -h, --help            show this help message and exit
+  --ckpt CKPT           Paths to the model checkpoint
+  --num_pred_steps NUM_PRED_STEPS
+                        Number of auto-regressive prediction steps.
+
+example: python bin/scores_comparison.py --ckpt /.../logs/my_run0/epoch=247.ckpt
+                                         --ckpt /.../logs/my_run1/epoch=247.ckpt
+                                         --num_pred_steps 10
+"""
+
 import json
 import math
 from argparse import ArgumentParser
@@ -62,7 +79,7 @@ if __name__ == "__main__":
         "--num_pred_steps",
         type=int,
         default=12,
-        help="Number of auto-regressive steps/prediction steps.",
+        help="Number of auto-regressive prediction steps.",
     )
     args = parser.parse_args()
 

--- a/bin/test.py
+++ b/bin/test.py
@@ -60,6 +60,7 @@ model.eval()
 print(f"Changing number of val pred steps to {args.num_pred_steps}...")
 hparams = model.hparams["hparams"]
 hparams.num_pred_steps_val_test = args.num_pred_steps
+hparams.save_path = args.ckpt_path.parent
 
 log_dir, folder, subfolder = get_log_dirs(args.ckpt_path)
 logger = TensorBoardLogger(

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import deepcopy
@@ -520,10 +521,18 @@ class StateErrorPlot(Plotter):
                 loss = torch.mean(loss_tensor, dim=0)
 
                 # Log metrics in tensorboard, with x axis as forecast timestep
+                loss_dict = {self.shortnames[k]: [] for k in range(loss.shape[1])}
                 for t in range(loss.shape[0]):
                     for k in range(loss.shape[1]):
                         scalar_name = f"{label}_{name}/timestep_{self.shortnames[k]}"
                         tensorboard.add_scalar(scalar_name, loss[t][k], t + 1)
+                        loss_dict[self.shortnames[k]].append(loss[t][k].item())
+
+                # Save metrics in json file
+                with open(
+                    self.save_path / f"{label}_{name}_scores.json", "w"
+                ) as json_file:
+                    json.dump(loss_dict, json_file)
 
                 # Plot the score card
                 if not obj.trainer.sanity_checking:

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -528,12 +528,6 @@ class StateErrorPlot(Plotter):
                         tensorboard.add_scalar(scalar_name, loss[t][k], t + 1)
                         loss_dict[self.shortnames[k]].append(loss[t][k].item())
 
-                # Save metrics in json file
-                with open(
-                    self.save_path / f"{label}_{name}_scores.json", "w"
-                ) as json_file:
-                    json.dump(loss_dict, json_file)
-
                 # Plot the score card
                 if not obj.trainer.sanity_checking:
                     fig = plot_error_map(
@@ -551,6 +545,13 @@ class StateErrorPlot(Plotter):
                         dest_file.parent.mkdir(exist_ok=True)
                         fig.savefig(dest_file)
                     plt.close(fig)
+
+                    if self.save_path is not None:
+                        # Save metrics in json file
+                        with open(
+                            self.save_path / f"{label}_{name}_scores.json", "w"
+                        ) as json_file:
+                            json.dump(loss_dict, json_file)
             # Free memory
             [self.losses[name].clear() for name in self.metrics]
 


### PR DESCRIPTION
- During test stage, score_cards RMSE are saved as a json in save folder, to be used for the plots
- Add `bin/scores_comparison.py` script to compare RMSE of multiple models on 4 surface parameters.
- Add usage doc in readme

Exemple plot :
![rmse_reproducibility](https://github.com/user-attachments/assets/417c5724-59c3-4a09-868d-a34af9f841bc)
