### PR TITLE
Fix restart from checkpoint

### DIFF
--- a/bin/train.py
+++ b/bin/train.py
@@ -369,12 +369,12 @@ if args.load_model_ckpt:
 else:
     lightning_module = AutoRegressiveLightning(hp)
 
-
 # Train model
 print("Starting training !")
 trainer.fit(
     model=lightning_module,
     datamodule=dm,
+    ckpt_path=args.load_model_ckpt
 )
 
 if not args.no_log:

--- a/bin/train.py
+++ b/bin/train.py
@@ -176,6 +176,12 @@ parser.add_argument(
     help="Path to load model parameters from (default: None)",
 )
 parser.add_argument(
+    "--resume_from_ckpt",
+    type=str,
+    default=None,
+    help="Path to load the whole training parameters from (default: None)",
+)
+parser.add_argument(
     "--strategy",
     type=str,
     default="diff_ar",
@@ -362,7 +368,7 @@ trainer = pl.Trainer(
     limit_test_batches=args.limit_train_batches,
 )
 
-if args.load_model_ckpt:
+if args.load_model_ckpt and not args.resume_from_ckpt:
     lightning_module = AutoRegressiveLightning.load_from_checkpoint(
         args.load_model_ckpt, hparams=hp
     )
@@ -371,9 +377,7 @@ else:
 
 # Train model
 print("Starting training !")
-trainer.fit(
-    model=lightning_module, datamodule=dm, ckpt_path=args.load_model_ckpt
-)
+trainer.fit(model=lightning_module, datamodule=dm, ckpt_path=args.resume_from_ckpt)
 
 if not args.no_log:
     # If we saved a model, we test it.

--- a/bin/train.py
+++ b/bin/train.py
@@ -372,9 +372,7 @@ else:
 # Train model
 print("Starting training !")
 trainer.fit(
-    model=lightning_module,
-    datamodule=dm,
-    ckpt_path=args.load_model_ckpt
+    model=lightning_module, datamodule=dm, ckpt_path=args.load_model_ckpt
 )
 
 if not args.no_log:

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -712,11 +712,11 @@ class AutoRegressiveLightning(pl.LightningModule):
             if self.current_epoch % PLOT_PERIOD == 0:
                 for plotter in self.valid_plotters:
                     plotter.update(self, prediction=prediction, target=target)
-                self.psd_plot_metric.update(prediction, target, self.original_shape)
-                self.rmse_psd_plot_metric.update(
-                    prediction, target, self.original_shape
-                )
-                self.acc_metric.update(prediction, target)
+            self.psd_plot_metric.update(prediction, target, self.original_shape)
+            self.rmse_psd_plot_metric.update(
+                prediction, target, self.original_shape
+            )
+            self.acc_metric.update(prediction, target)
 
     def on_validation_epoch_end(self):
         """

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -713,9 +713,7 @@ class AutoRegressiveLightning(pl.LightningModule):
                 for plotter in self.valid_plotters:
                     plotter.update(self, prediction=prediction, target=target)
             self.psd_plot_metric.update(prediction, target, self.original_shape)
-            self.rmse_psd_plot_metric.update(
-                prediction, target, self.original_shape
-            )
+            self.rmse_psd_plot_metric.update(prediction, target, self.original_shape)
             self.acc_metric.update(prediction, target)
 
     def on_validation_epoch_end(self):

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -197,9 +197,6 @@ class AutoRegressiveLightning(pl.LightningModule):
         # Keeping track of grid shape
         self.grid_shape = statics.grid_shape
 
-        # For making restoring of optimizer state optional (slight hack)
-        self.opt_state = None
-
         # For example plotting
         self.plotted_examples = 0
 
@@ -338,9 +335,6 @@ class AutoRegressiveLightning(pl.LightningModule):
     def configure_optimizers(self) -> torch.optim.Optimizer:
         lr = self.hparams["hparams"].lr
         opt = torch.optim.AdamW(self.parameters(), lr=lr, betas=(0.9, 0.95))
-        if self.opt_state:
-            opt.load_state_dict(self.opt_state)
-
         if self.hparams["hparams"].use_lr_scheduler:
             len_loader = self.hparams["hparams"].len_train_loader // LR_SCHEDULER_PERIOD
             epochs = self.trainer.max_epochs


### PR DESCRIPTION
- use the `trainer.fit()` to load the checkpoint in case of full training resume
- fix the `Metric.compute()` called before  `Metric.update()`. Ffor any reason that was blocking in restart mode but not starting a training from scratch (even if a warning was displayed `UserWarning: The compute method of metric MetricPSDK was called before the update method which may lead to errors, as metric states have not yet been updated.`)

Solve #98 