### PR TITLE
Add an optional MLFlow logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,28 +424,8 @@ python bin/train.py --dataset smeagol --model halfunet --strategy diff_ar
 
 [Details on available training strategies.](doc/features.md/#available-training-strategies)
 
-### Tracking experiment
 
-We use [Tensorboad](https://www.tensorflow.org/tensorboard) to track the experiments. You can launch a tensorboard server using the following command:
-
-**At Météo-France**:
-
-**runai** will handle port forwarding for you.
-
-```bash
-runai tensorboard --logdir PATH_TO_YOUR_ROOT_PATH
-```
-
-**Elsewhere**
-
-```bash
-tensorboard --logdir PATH_TO_YOUR_ROOT_PATH
-```
-
-Then you can access the tensorboard server at the following address: `http://YOUR_SERVER_IP:YOUR_PORT/`
-
-
-4. **Other training options**:
+3. **Other training options**:
 
 * `--seed SEED`           random seed (default: 42)
 * `--loss LOSS`           Loss function to use (default: mse)
@@ -469,7 +449,9 @@ Then you can access the tensorboard server at the following address: `http://YOU
 * `--num_inter_steps NUM_INTER_STEPS`
                     Number of model steps between two samples
 * `--no_log`
-    When activated, log are not stored and models are not saved. Use in dev mode. (default: False)
+    When activated, logs are not stored and models are not saved. Use in dev mode. (default: False)
+* `--mlflow_log`
+    When activated, the MLFlowLogger is used and the model is saved in the MLFlow style (default: False)
 * `--dev_mode`
     When activated, reduce number of epoch and steps. (default: False)
 * `--load_model_ckpt LOAD_MODEL_CKPT`
@@ -477,6 +459,51 @@ Then you can access the tensorboard server at the following address: `http://YOU
 
 
 You can find more details about all the `num_X_steps` options [here](doc/num_steps.md).
+
+
+### Tracking experiment
+
+#### Tensorboard
+
+We use [Tensorboad](https://www.tensorflow.org/tensorboard) to track the experiments. You can launch a tensorboard server using the following command:
+
+**At Météo-France**:
+
+**runai** will handle port forwarding for you.
+
+```bash
+runai tensorboard --logdir PATH_TO_YOUR_ROOT_PATH
+```
+
+**Elsewhere**
+
+```bash
+tensorboard --logdir PATH_TO_YOUR_ROOT_PATH
+```
+
+Then you can access the tensorboard server at the following address: `http://YOUR_SERVER_IP:YOUR_PORT/`
+
+
+#### MLFlow
+
+Optionally, you can use MLFlow, in addition to Tensorboard, to track your experiment and log your model. To activate the MLFlow logger simply add the `--mlflow_log` option on the `bin/train.py` command line.
+
+**Local usage**
+
+Without a MLFlow server, the logs are stored in your root path, at `PY4CAST_ROOTDIR/logs/mlflow`.
+
+**With a MLFlow server**
+
+If you have a MLFow server you can configure your training environment to push the logs on the remote server. A set of [environment variables](https://mlflow.org/docs/latest/cli.html#mlflow-server) are available to do that.
+
+For exemple, you can export the following variable in your training environment:
+
+```bash
+export MLFLOW_TRACKING_URI=https://my.mlflow.server.com/
+export MLFLOW_TRACKING_USERNAME=<your-mlflow-user>
+export MLFLOW_TRACKING_PASSWORD=<your-mlflow-pwd>
+export MLFLOW_EXPERIMENT_NAME=py4cast/unetrpp
+```
 
 ### Inference
 

--- a/bin/train.py
+++ b/bin/train.py
@@ -9,6 +9,8 @@ import os
 from argparse import ArgumentParser, BooleanOptionalAction
 from datetime import datetime
 from pathlib import Path
+import mlflow.pytorch
+from mlflow.models.signature import infer_signature
 
 import pytorch_lightning as pl
 import torch
@@ -27,10 +29,6 @@ from py4cast.lightning import (
 )
 from py4cast.models import registry as model_registry
 from py4cast.settings import ROOTDIR
-
-import mlflow.tracking
-import mlflow.pytorch
-from mlflow.models.signature import infer_signature
 
 layout = {
     "Check Overfit": {
@@ -402,6 +400,7 @@ if not args.no_log:
     )
     trainer.test(ckpt_path=model_to_test, datamodule=dm)
 
+# Finally log the model in a MLFlow fashion
 if trainer.global_rank == 0:
     # Get random sample to infer the signature of the model
     dataloader = dm.test_dataloader()

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -733,7 +733,7 @@ class AutoRegressiveLightning(pl.LightningModule):
                         self.loggers[1].experiment.log_figure(
                             run_id=run_id,
                             figure=elmnt,
-                            artifact_file=f"figures/{name}.png"
+                            artifact_file=f"figures/{name}.png",
                         )
                 elif isinstance(elmnt, torch.Tensor):
                     self.log_dict(
@@ -831,7 +831,7 @@ class AutoRegressiveLightning(pl.LightningModule):
                         self.loggers[1].experiment.log_figure(
                             run_id=run_id,
                             figure=elmnt,
-                            artifact_file=f"figures/{name}.png"
+                            artifact_file=f"figures/{name}.png",
                         )
                 elif isinstance(elmnt, torch.Tensor):
                     self.log_dict(

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -828,11 +828,8 @@ class AutoRegressiveLightning(pl.LightningModule):
             dict_metrics.update(self.rmse_psd_plot_metric.compute(prefix="test"))
             dict_metrics.update(self.acc_metric.compute(prefix="test"))
 
-            mlflow_logger_idx = [
-                i for i, l in enumerate(self.loggers) if isinstance(l, MLFlowLogger)
-            ]
-            mlflow_logger = (
-                self.loggers[mlflow_logger_idx[0]] if mlflow_logger_idx else None
+            mlflow_logger = next(
+                iter([o for o in self.loggers if isinstance(o, MLFlowLogger)]), None
             )
 
             for name, elmnt in dict_metrics.items():

--- a/py4cast/metrics.py
+++ b/py4cast/metrics.py
@@ -74,7 +74,7 @@ class MetricPSDK(Metric):
             preds.flatten_("ngrid", 2, 3)
             targets.flatten_("ngrid", 2, 3)
 
-    def compute(self, prefix : str = "val") -> dict:
+    def compute(self, prefix: str = "val") -> dict:
         """
         Compute PSD mean for each channels/features, plot the figure, return a dict.
         Should be called at each epoch's end
@@ -102,7 +102,8 @@ class MetricPSDK(Metric):
             )
             dict_psd_metric[f"{prefix}_mean_psd_k/{features_name[c]}"] = fig
             dest_file = (
-                self.save_path / f"{prefix}_mean_psd_k/{features_name[c]}_{self.pred_step+1}.png"
+                self.save_path
+                / f"{prefix}_mean_psd_k/{features_name[c]}_{self.pred_step+1}.png"
             )
             if self.save_path.exists():
                 dest_file.parent.mkdir(exist_ok=True)
@@ -217,7 +218,7 @@ class MetricPSDVar(Metric):
             preds.flatten_("ngrid", 2, 3)
             targets.flatten_("ngrid", 2, 3)
 
-    def compute(self, prefix : str = "val") -> dict:
+    def compute(self, prefix: str = "val") -> dict:
         """
         Compute PSD mean for each channels/features, return a dict.
         Should be called at each epoch's end
@@ -415,7 +416,7 @@ class MetricACC(Metric):
         # Increment step_count
         self.step_count += 1
 
-    def compute(self, prefix : str = "val") -> dict:
+    def compute(self, prefix: str = "val") -> dict:
         """
         Compute ACC mean for each channels/features, return a dict.
         Should be called at each epoch's end

--- a/py4cast/metrics.py
+++ b/py4cast/metrics.py
@@ -74,7 +74,7 @@ class MetricPSDK(Metric):
             preds.flatten_("ngrid", 2, 3)
             targets.flatten_("ngrid", 2, 3)
 
-    def compute(self) -> dict:
+    def compute(self, prefix : str = "val") -> dict:
         """
         Compute PSD mean for each channels/features, plot the figure, return a dict.
         Should be called at each epoch's end
@@ -100,9 +100,9 @@ class MetricPSDK(Metric):
                 mean_psd_target[c].cpu().numpy(),
                 f"PSD for {features_name[c]} at +{self.pred_step+1}h",
             )
-            dict_psd_metric[f"mean_psd_k/{features_name[c]}"] = fig
+            dict_psd_metric[f"{prefix}_mean_psd_k/{features_name[c]}"] = fig
             dest_file = (
-                self.save_path / f"mean_psd_k/{features_name[c]}_{self.pred_step+1}.png"
+                self.save_path / f"{prefix}_mean_psd_k/{features_name[c]}_{self.pred_step+1}.png"
             )
             if self.save_path.exists():
                 dest_file.parent.mkdir(exist_ok=True)
@@ -217,7 +217,7 @@ class MetricPSDVar(Metric):
             preds.flatten_("ngrid", 2, 3)
             targets.flatten_("ngrid", 2, 3)
 
-    def compute(self) -> dict:
+    def compute(self, prefix : str = "val") -> dict:
         """
         Compute PSD mean for each channels/features, return a dict.
         Should be called at each epoch's end
@@ -228,7 +228,7 @@ class MetricPSDVar(Metric):
 
         # dict {"feature_name" : RMSE mean}
         metric_log_dict = {
-            f"val_rmse_psd/{name}": mean_psd_rmse[i]
+            f"{prefix}_rmse_psd/{name}": mean_psd_rmse[i]
             for i, name in enumerate(feature_names)
         }
 
@@ -373,7 +373,7 @@ class MetricACC(Metric):
         # Step counter, needed to compute psd mean at each epoch.
         self.add_state("step_count", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
-    def update(self, preds: NamedTensor, target: NamedTensor):
+    def update(self, preds: NamedTensor, target: NamedTensor, *args):
         """
         compute the ACC between target and pred.
         prediction/target: (B, pred_steps, N_grid, d_f) or (B, pred_steps, W, H, d_f)
@@ -415,7 +415,7 @@ class MetricACC(Metric):
         # Increment step_count
         self.step_count += 1
 
-    def compute(self) -> dict:
+    def compute(self, prefix : str = "val") -> dict:
         """
         Compute ACC mean for each channels/features, return a dict.
         Should be called at each epoch's end
@@ -426,7 +426,7 @@ class MetricACC(Metric):
 
         # dict {"feature_name" : RMSE mean}
         metric_log_dict = {
-            f"val_acc/{name}_step{j}": mean_acc[j, i]
+            f"{prefix}_acc/{name}_step{j}": mean_acc[j, i]
             for i, name in enumerate(feature_names)
             for j in range(self.pred_steps)
         }

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -12,7 +12,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from lightning.pytorch.loggers import MLFlowLogger
 from PIL import Image
 from tueplots import bundles, figsizes
 
@@ -391,9 +390,6 @@ class PredictionTimestepPlot(MapPlot):
             ]
             # TODO : don't create all figs at once to avoid matplotlib warning
             tensorboard = obj.logger.experiment
-            mlflow_logger = next(
-                iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
-            )
             for var_name, fig in zip(feature_names, var_figs):
                 fig_name = f"timestep_evol_per_param/{var_name}_example_{self.plotted_examples}"
                 tensorboard.add_figure(fig_name, fig, t_i)
@@ -404,9 +400,9 @@ class PredictionTimestepPlot(MapPlot):
                     dest_file.parent.mkdir(exist_ok=True)
                     fig.savefig(dest_file)
 
-                if mlflow_logger:
-                    run_id = mlflow_logger.version
-                    mlflow_logger.experiment.log_figure(
+                if obj.mlflow_logger:
+                    run_id = obj.mlflow_logger.version
+                    obj.mlflow_logger.experiment.log_figure(
                         run_id=run_id,
                         figure=fig,
                         artifact_file=f"figures/{fig_full_name}",
@@ -465,9 +461,6 @@ class PredictionEpochPlot(MapPlot):
         ]
 
         tensorboard = obj.logger.experiment
-        mlflow_logger = next(
-            iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
-        )
         for var_name, fig in zip(feature_names, var_figs):
             fig_name = (
                 f"epoch_evol_per_param/{var_name}_example_{self.plotted_examples}"
@@ -479,9 +472,9 @@ class PredictionEpochPlot(MapPlot):
                 dest_file.parent.mkdir(exist_ok=True)
                 fig.savefig(dest_file)
 
-            if mlflow_logger:
-                run_id = mlflow_logger.version
-                mlflow_logger.experiment.log_figure(
+            if obj.mlflow_logger:
+                run_id = obj.mlflow_logger.version
+                obj.mlflow_logger.experiment.log_figure(
                     run_id=run_id, figure=fig, artifact_file=f"figures/{fig_full_name}"
                 )
 
@@ -538,9 +531,6 @@ class StateErrorPlot(Plotter):
         Make the summary figure
         """
         tensorboard = obj.logger.experiment
-        mlflow_logger = next(
-            iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
-        )
         if obj.trainer.is_global_zero:
             for name in self.metrics:
                 loss_tensor = torch.cat(self.losses[name], dim=0)
@@ -572,9 +562,9 @@ class StateErrorPlot(Plotter):
                         dest_file.parent.mkdir(exist_ok=True)
                         fig.savefig(dest_file)
 
-                    if mlflow_logger:
-                        run_id = mlflow_logger.version
-                        mlflow_logger.experiment.log_figure(
+                    if obj.mlflow_logger:
+                        run_id = obj.mlflow_logger.version
+                        obj.mlflow_logger.experiment.log_figure(
                             run_id=run_id,
                             figure=fig,
                             artifact_file=f"figures/{fig_full_name}",
@@ -637,17 +627,14 @@ class SpatialErrorPlot(Plotter):
                 for t_i, loss_map in enumerate(mean_spatial_loss)
             ]
             tensorboard = obj.logger.experiment
-            mlflow_logger = next(
-                iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
-            )
 
             for t_i, fig in enumerate(loss_map_figs):
                 fig_full_name = f"spatial_error_{label}/{self.prefix}_loss"
                 tensorboard.add_figure(fig_full_name, fig, t_i)
 
-                if mlflow_logger:
-                    run_id = mlflow_logger.version
-                    mlflow_logger.experiment.log_figure(
+                if obj.mlflow_logger:
+                    run_id = obj.mlflow_logger.version
+                    obj.mlflow_logger.experiment.log_figure(
                         run_id=run_id,
                         figure=fig,
                         artifact_file=f"figures/{fig_full_name}.png",

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -391,11 +391,8 @@ class PredictionTimestepPlot(MapPlot):
             ]
             # TODO : don't create all figs at once to avoid matplotlib warning
             tensorboard = obj.logger.experiment
-            mlflow_logger_idx = [
-                i for i, l in enumerate(obj.loggers) if isinstance(l, MLFlowLogger)
-            ]
-            mlflow_logger = (
-                obj.loggers[mlflow_logger_idx[0]] if mlflow_logger_idx else None
+            mlflow_logger = next(
+                iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
             )
             for var_name, fig in zip(feature_names, var_figs):
                 fig_name = f"timestep_evol_per_param/{var_name}_example_{self.plotted_examples}"
@@ -468,10 +465,9 @@ class PredictionEpochPlot(MapPlot):
         ]
 
         tensorboard = obj.logger.experiment
-        mlflow_logger_idx = [
-            i for i, l in enumerate(obj.loggers) if isinstance(l, MLFlowLogger)
-        ]
-        mlflow_logger = obj.loggers[mlflow_logger_idx[0]] if mlflow_logger_idx else None
+        mlflow_logger = next(
+            iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
+        )
         for var_name, fig in zip(feature_names, var_figs):
             fig_name = (
                 f"epoch_evol_per_param/{var_name}_example_{self.plotted_examples}"
@@ -542,10 +538,9 @@ class StateErrorPlot(Plotter):
         Make the summary figure
         """
         tensorboard = obj.logger.experiment
-        mlflow_logger_idx = [
-            i for i, l in enumerate(obj.loggers) if isinstance(l, MLFlowLogger)
-        ]
-        mlflow_logger = obj.loggers[mlflow_logger_idx[0]] if mlflow_logger_idx else None
+        mlflow_logger = next(
+            iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
+        )
         if obj.trainer.is_global_zero:
             for name in self.metrics:
                 loss_tensor = torch.cat(self.losses[name], dim=0)
@@ -642,11 +637,8 @@ class SpatialErrorPlot(Plotter):
                 for t_i, loss_map in enumerate(mean_spatial_loss)
             ]
             tensorboard = obj.logger.experiment
-            mlflow_logger_idx = [
-                i for i, l in enumerate(obj.loggers) if isinstance(l, MLFlowLogger)
-            ]
-            mlflow_logger = (
-                obj.loggers[mlflow_logger_idx[0]] if mlflow_logger_idx else None
+            mlflow_logger = next(
+                iter([o for o in obj.loggers if isinstance(o, MLFlowLogger)]), None
             )
 
             for t_i, fig in enumerate(loss_map_figs):

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -393,14 +393,21 @@ class PredictionTimestepPlot(MapPlot):
             for var_name, fig in zip(feature_names, var_figs):
                 fig_name = f"timestep_evol_per_param/{var_name}_example_{self.plotted_examples}"
                 tensorboard.add_figure(fig_name, fig, t_i)
+                fig_full_name = f"{fig_name}_{t_i}.png"
                 if self.save_path is not None and self.save_path.exists():
-                    dest_file = self.save_path / f"{fig_name}_{t_i}.png"
+                    dest_file = self.save_path / fig_full_name
                     paths_dict[var_name].append(dest_file)
                     dest_file.parent.mkdir(exist_ok=True)
                     fig.savefig(dest_file)
 
-                run_id = obj.loggers[1].version
-                obj.loggers[1].experiment.log_figure(run_id=run_id, figure=fig, artifact_file=f"{fig_name}_{t_i}.png")
+                # Suppose the obj.loggers[1] is the MLFlowLogger
+                if len(obj.loggers) > 1:
+                    run_id = obj.loggers[1].version
+                    obj.loggers[1].experiment.log_figure(
+                        run_id=run_id,
+                        figure=fig,
+                        artifact_file=f"figures/{fig_full_name}"
+                    )
 
                 plt.close(fig)
 
@@ -460,10 +467,20 @@ class PredictionEpochPlot(MapPlot):
                 f"epoch_evol_per_param/{var_name}_example_{self.plotted_examples}"
             )
             tensorboard.add_figure(fig_name, fig, obj.current_epoch)
+            fig_full_name = f"{fig_name}_{obj.current_epoch}.png"
             if self.save_path is not None:
-                dest_file = self.save_path / f"{fig_name}_{obj.current_epoch}.png"
+                dest_file = self.save_path / fig_full_name
                 dest_file.parent.mkdir(exist_ok=True)
                 fig.savefig(dest_file)
+
+            # Suppose the obj.loggers[1] is the MLFlowLogger
+            if len(obj.loggers) > 1:
+                run_id = obj.loggers[1].version
+                obj.loggers[1].experiment.log_figure(
+                    run_id=run_id,
+                    figure=fig,
+                    artifact_file=f"figures/{fig_full_name}"
+                )
 
         plt.close("all")  # Close all figs for this time step, saves memory
 
@@ -543,10 +560,19 @@ class StateErrorPlot(Plotter):
                     # log it in tensorboard
                     fig_name = f"score_cards/{self.prefix}_{name}"
                     tensorboard.add_figure(fig_name, fig, obj.current_epoch)
+                    fig_full_name = f"{fig_name}.png"
                     if self.save_path is not None:
-                        dest_file = self.save_path / f"{fig_name}.png"
+                        dest_file = self.save_path / fig_full_name
                         dest_file.parent.mkdir(exist_ok=True)
                         fig.savefig(dest_file)
+                    # Suppose the obj.loggers[1] is the MLFlowLogger
+                    if len(obj.loggers) > 1:
+                        run_id = obj.loggers[1].version
+                        obj.loggers[1].experiment.log_figure(
+                            run_id=run_id,
+                            figure=fig,
+                            artifact_file=f"figures/{fig_full_name}"
+                        )
                     plt.close(fig)
 
                     if self.save_path is not None:
@@ -606,9 +632,18 @@ class SpatialErrorPlot(Plotter):
             ]
             tensorboard = obj.logger.experiment
             for t_i, fig in enumerate(loss_map_figs):
+                fig_full_name = f"spatial_error_{label}/{self.prefix}_loss"
                 tensorboard.add_figure(
-                    f"spatial_error_{label}/{self.prefix}_loss", fig, t_i
+                    fig_full_name, fig, t_i
                 )
+                # Suppose the obj.loggers[1] is the MLFlowLogger
+                if len(obj.loggers) > 1:
+                    run_id = obj.loggers[1].version
+                    obj.loggers[1].experiment.log_figure(
+                        run_id=run_id,
+                        figure=fig,
+                        artifact_file=f"figures/{fig_full_name}.png"
+                    )
             plt.close()
 
         self.spatial_loss_maps.clear()

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -406,7 +406,7 @@ class PredictionTimestepPlot(MapPlot):
                     obj.loggers[1].experiment.log_figure(
                         run_id=run_id,
                         figure=fig,
-                        artifact_file=f"figures/{fig_full_name}"
+                        artifact_file=f"figures/{fig_full_name}",
                     )
 
                 plt.close(fig)
@@ -477,9 +477,7 @@ class PredictionEpochPlot(MapPlot):
             if len(obj.loggers) > 1:
                 run_id = obj.loggers[1].version
                 obj.loggers[1].experiment.log_figure(
-                    run_id=run_id,
-                    figure=fig,
-                    artifact_file=f"figures/{fig_full_name}"
+                    run_id=run_id, figure=fig, artifact_file=f"figures/{fig_full_name}"
                 )
 
         plt.close("all")  # Close all figs for this time step, saves memory
@@ -571,7 +569,7 @@ class StateErrorPlot(Plotter):
                         obj.loggers[1].experiment.log_figure(
                             run_id=run_id,
                             figure=fig,
-                            artifact_file=f"figures/{fig_full_name}"
+                            artifact_file=f"figures/{fig_full_name}",
                         )
                     plt.close(fig)
 
@@ -633,16 +631,14 @@ class SpatialErrorPlot(Plotter):
             tensorboard = obj.logger.experiment
             for t_i, fig in enumerate(loss_map_figs):
                 fig_full_name = f"spatial_error_{label}/{self.prefix}_loss"
-                tensorboard.add_figure(
-                    fig_full_name, fig, t_i
-                )
+                tensorboard.add_figure(fig_full_name, fig, t_i)
                 # Suppose the obj.loggers[1] is the MLFlowLogger
                 if len(obj.loggers) > 1:
                     run_id = obj.loggers[1].version
                     obj.loggers[1].experiment.log_figure(
                         run_id=run_id,
                         figure=fig,
-                        artifact_file=f"figures/{fig_full_name}.png"
+                        artifact_file=f"figures/{fig_full_name}.png",
                     )
             plt.close()
 

--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -399,6 +399,9 @@ class PredictionTimestepPlot(MapPlot):
                     dest_file.parent.mkdir(exist_ok=True)
                     fig.savefig(dest_file)
 
+                run_id = obj.loggers[1].version
+                obj.loggers[1].experiment.log_figure(run_id=run_id, figure=fig, artifact_file=f"{fig_name}_{t_i}.png")
+
                 plt.close(fig)
 
         for var_name, paths in paths_dict.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ scikit-image==0.24.0
 typer==0.12.5
 transformers==4.45.2
 torch-geometric==2.6.1
+mlflow==2.17.2


### PR DESCRIPTION
This PR resolves #99 with the following additions:
- add the possibility to log with the `MLFlowLogger`, in addition to thre `TensorboardLogger`, using the `--mlflow_log` option of the `bin/train.py` CLI,
- log the trained model in the MLFlow fashion at the final step of `train.py`, if the  `--mlflow_log` option is activated,
- add logging of metrics at the test stage,
- document the MLFlow logger output configuration