### PR TITLE
Downscaling

### DIFF
--- a/py4cast/datasets/titan/__init__.py
+++ b/py4cast/datasets/titan/__init__.py
@@ -323,6 +323,8 @@ class Sample:
                 tmp_state = NamedTensor(tensor=tensor, **deepcopy(state_kwargs))
                 loutputs.append(tmp_state)
 
+                linputs.append(NamedTensor(tensor=torch.zeros_like(tensor),**deepcopy(state_kwargs)))
+
             else:  # input_output
                 tensor = self.get_param_tensor(param, self.all_dates, no_standardize)
                 state_kwargs["names"][0] = "timestep"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,3 @@ method_length = 58
 method_cyclomatic_complexity = 22
 method_cognitive_complexity = 34
 method_working_memory = 45
-
-[project.optional-dependencies]
-MF = ["tornado==6.4.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ method_length = 58
 method_cyclomatic_complexity = 22
 method_cognitive_complexity = 34
 method_working_memory = 45
+
+[project.optional-dependencies]
+MF = ["tornado==6.4.1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ scikit-image==0.24.0
 typer==0.12.5
 transformers==4.45.2
 torch-geometric==2.6.1
-tornado==6.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ scikit-image==0.24.0
 typer==0.12.5
 transformers==4.45.2
 torch-geometric==2.6.1
+tornado==6.4.1


### PR DESCRIPTION
For downscaling experiment, there is no more data as inputs. The returned dataset item, constitued by namedTensor will return an error as the inputs are empty. 
'''
Item(
            inputs=NamedTensor.concat(linputs),
            outputs=NamedTensor.concat(loutputs),
            forcing=NamedTensor.concat(lforcings),
'''
Here I try to create a zeros_like tensor for linputs, with same dimension and feature names as loutputs.

This leads to the following error : 

Sanity Checking DataLoader 0:   0%|                                                                                                                               | 0/2 [00:00<?, ?it/s][rank0]: Traceback (most recent call last):
[rank0]:   File "/home/mrmn/akodads/py4cast/bin/train.py", line 400, in <module>
[rank0]:     trainer.fit(model=lightning_module, datamodule=dm, ckpt_path=args.resume_from_ckpt)
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/trainer.py", line 538, in fit
[rank0]:     call._call_and_handle_interrupt(
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/call.py", line 46, in _call_and_handle_interrupt
[rank0]:     return trainer.strategy.launcher.launch(trainer_fn, *args, trainer=trainer, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/strategies/launchers/subprocess_script.py", line 105, in launch
[rank0]:     return function(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/trainer.py", line 574, in _fit_impl
[rank0]:     self._run(model, ckpt_path=ckpt_path)
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/trainer.py", line 981, in _run
[rank0]:     results = self._run_stage()
[rank0]:               ^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/trainer.py", line 1023, in _run_stage
[rank0]:     self._run_sanity_check()
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/trainer.py", line 1052, in _run_sanity_check
[rank0]:     val_loop.run()
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/loops/utilities.py", line 178, in _decorator
[rank0]:     return loop_run(self, *args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/loops/evaluation_loop.py", line 135, in run
[rank0]:     self._evaluation_step(batch, batch_idx, dataloader_idx, dataloader_iter)
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/loops/evaluation_loop.py", line 396, in _evaluation_step
[rank0]:     output = call._call_strategy_hook(trainer, hook_name, *step_args)
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/trainer/call.py", line 319, in _call_strategy_hook
[rank0]:     output = fn(*args, **kwargs)
[rank0]:              ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/strategies/strategy.py", line 410, in validation_step
[rank0]:     return self._forward_redirection(self.model, self.lightning_module, "validation_step", *args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/strategies/strategy.py", line 640, in __call__
[rank0]:     wrapper_output = wrapper_module(*args, **kwargs)
[rank0]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/parallel/distributed.py", line 1636, in forward
[rank0]:     else self._run_ddp_forward(*inputs, **kwargs)
[rank0]:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/parallel/distributed.py", line 1454, in _run_ddp_forward
[rank0]:     return self.module(*inputs, **kwargs)  # type: ignore[index]
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/pytorch_lightning/strategies/strategy.py", line 633, in wrapped_forward
[rank0]:     out = method(*_args, **_kwargs)
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/lightning.py", line 698, in validation_step
[rank0]:     prediction, target, mean_loss = self._shared_val_test_step(
[rank0]:                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/lightning.py", line 673, in _shared_val_test_step
[rank0]:     prediction, target = self.common_step(batch)
[rank0]:                          ^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/lightning.py", line 427, in common_step
[rank0]:     return self._common_step(batch, inference)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/lightning.py", line 490, in _common_step
[rank0]:     y = self.model(x)
[rank0]:         ^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/models/vision/unetrpp.py", line 811, in forward
[rank0]:     _, hidden_states = self.unetr_pp_encoder(x_in)
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/models/vision/unetrpp.py", line 454, in forward
[rank0]:     x, hidden_states = self.forward_features(x)
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mrmn/akodads/py4cast/py4cast/models/vision/unetrpp.py", line 437, in forward_features
[rank0]:     x = self.downsample_layers[0](x)
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/container.py", line 219, in forward
[rank0]:     input = module(input)
[rank0]:             ^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/container.py", line 219, in forward
[rank0]:     input = module(input)
[rank0]:             ^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/conv.py", line 458, in forward
[rank0]:     return self._conv_forward(input, self.weight, self.bias)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/conda/lib/python3.11/site-packages/torch/nn/modules/conv.py", line 454, in _conv_forward
[rank0]:     return F.conv2d(input, weight, bias, self.stride,
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Given groups=1, weight of size [32, 26, 4, 4], expected input[1, 47, 512, 640] to have 26 channels, but got 47 channels instead
