### PR TITLE
Make the Dockerfile less adherent to MF env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-de
 ###################################################
 FROM base_crt_injected_0 as base_crt_injected_1
 
+ARG INJECT_MF_CERT
+
 # The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
 COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
@@ -27,6 +29,9 @@ ENV CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
 ### Final image inherited from the base image ###
 #################################################
 FROM base_crt_injected_${INJECT_MF_CERT}
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 
 # set apt to non interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,23 @@ ARG CUDA_VERS=12.1
 
 ARG INJECT_MF_CERT
 
+
+#####################################################
+### Default base image if no crt file is provided ###
+#####################################################
+FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_0
+
+
 ###################################################
 ### Custom base image if a crt file is provided ###
 ###################################################
-FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_1
+FROM BASE_CRT_INJECTED_0 as BASE_CRT_INJECTED_1
 
 COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 # The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
 ENV REQUESTS_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
 ENV CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
-
-
-#####################################################
-### Default base image if no crt file is provided ###
-#####################################################
-FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_0
 
 
 #################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ ARG INJECT_MF_CERT
 #####################################################
 ### Default base image if no crt file is provided ###
 #####################################################
-FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_0
+FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as base_crt_injected_0
 
 
 ###################################################
 ### Custom base image if a crt file is provided ###
 ###################################################
-FROM BASE_CRT_INJECTED_0 as BASE_CRT_INJECTED_1
+FROM base_crt_injected_0 as base_crt_injected_1
 
-COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 # The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
+COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
 ENV REQUESTS_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
 ENV CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
@@ -26,7 +26,7 @@ ENV CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
 #################################################
 ### Final image inherited from the base image ###
 #################################################
-FROM BASE_CRT_INJECTED_${INJECT_MF_CERT}
+FROM base_crt_injected_${INJECT_MF_CERT}
 
 # set apt to non interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,31 @@ ARG DOCKER_REGISTRY=docker.io
 ARG TORCH_VERS=2.4.1
 ARG CUDA_VERS=12.1
 
-FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel
-
 ARG INJECT_MF_CERT
 
-COPY mf.crt /usr/local/share/ca-certificates/mf.crt
+###################################################
+### Custom base image if a crt file is provided ###
+###################################################
+FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_1
 
+COPY mf.crt /usr/local/share/ca-certificates/mf.crt
 # The following two lines are necessary to deal with the MITM sniffing proxy we have internally.
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
+ENV REQUESTS_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
+ENV CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
+
+
+#####################################################
+### Default base image if no crt file is provided ###
+#####################################################
+FROM ${DOCKER_REGISTRY}/pytorch/pytorch:${TORCH_VERS}-cuda${CUDA_VERS}-cudnn9-devel as BASE_CRT_INJECTED_0
+
+
+#################################################
+### Final image inherited from the base image ###
+#################################################
+FROM BASE_CRT_INJECTED_${INJECT_MF_CERT}
+
 # set apt to non interactive
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MY_APT='apt -o "Acquire::https::Verify-Peer=false" -o "Acquire::AllowInsecureRepositories=true" -o "Acquire::AllowDowngradeToInsecureRepositories=true" -o "Acquire::https::Verify-Host=false"'
@@ -19,13 +36,6 @@ RUN $MY_APT update && $MY_APT install -y curl gdal-bin libgdal-dev libgeos-dev g
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
-
-ARG REQUESTS_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
-ARG CURL_CA_BUNDLE="/usr/local/share/ca-certificates/mf.crt"
-
-# Build eccodes, a recent version yields far better throughput according to our benchmarks
-ARG ECCODES_VER=2.35.0
-RUN curl -O https://confluence.ecmwf.int/download/attachments/45757960/eccodes-$ECCODES_VER-Source.tar.gz && tar -xzf eccodes-$ECCODES_VER-Source.tar.gz && mkdir build && cd build && cmake ../eccodes-$ECCODES_VER-Source -DENABLE_AEC=ON -DENABLE_NETCDF=ON -DENABLE_FORTRAN=OFF && make && ctest && make install && ldconfig
 
 RUN pip install --upgrade pip
 COPY requirements.txt /app/requirements.txt

--- a/oci-image-build.sh
+++ b/oci-image-build.sh
@@ -60,5 +60,7 @@ ${RUNTIME} build \
     --build-arg USER_GUID=$(id -g) \
     --build-arg HOME_DIR=${HOME} \
     --build-arg INJECT_MF_CERT=${INJECT_MF_CERT} \
+    --build-arg HTTP_PROXY=${HTTP_PROXY:=${http_proxy}} \
+    --build-arg HTTPS_PROXY=${HTTPS_PROXY:=${https_proxy}} \
     --tag py4cast:${TAG} \
     .

--- a/oci-image-build.sh
+++ b/oci-image-build.sh
@@ -39,6 +39,13 @@ else
   echo "PY4CAST_TORCH_VERSION version found in the environment: ${PY4CAST_TORCH_VERSION}"
 fi
 
+# Set the INJECT_MF_CERT env var it does not exist
+if [[ -z "${INJECT_MF_CERT}" ]]; then
+  INJECT_MF_CERT=0
+else
+  echo "INJECT_MF_CERT version found in the environment: ${INJECT_MF_CERT}"
+fi
+
 # Tag the docker image with the latest commit hash on the currrent branch
 TAG=$(git rev-parse --short HEAD)
 


### PR DESCRIPTION
* add the possibility to skip crt copy in docker image build, according to the INJECT_MF_CERT value (resolve #95)
* remove manual eccode install from source, while the python package is now standalone