### PR TITLE
correct itembatch input step

### DIFF
--- a/py4cast/datasets/base.py
+++ b/py4cast/datasets/base.py
@@ -156,7 +156,7 @@ class ItemBatch(Item):
 
     @cached_property
     def num_input_steps(self):
-        return self.outputs.dim_size("timestep")
+        return self.inputs.dim_size("timestep")
 
     @cached_property
     def num_pred_steps(self):


### PR DESCRIPTION
Correct bug of batchItem. The number of input step should be equal of the number of time steps of the input.