### PR TITLE
upgrade mfai to commit e6fccce, NamedTensor rework

### DIFF
--- a/py4cast/io/outputs.py
+++ b/py4cast/io/outputs.py
@@ -94,7 +94,7 @@ def save_named_tensors_to_grib(
     for t_idx in range(predicted_time_steps):
         leadtime = t_idx + 1
         for group in model_ds.keys():
-            raw_data = pred.select_dim("timestep", t_idx, bare_tensor=False)
+            raw_data = pred.select_dim("timestep", t_idx)
             storable = write_storable_dataset(
                 pred,
                 ds,
@@ -182,7 +182,7 @@ def write_storable_dataset(
     tol = used_grib_feat["typeOfLevel"].drop_duplicates().tolist()[0]
     feature_idx = torch.tensor([pred.feature_names_to_idx[f] for f in feature_names])
 
-    data = raw_data.index_select_dim("features", feature_idx).squeeze().cpu().numpy()
+    data = raw_data.index_select_tensor_dim("features", feature_idx).squeeze().cpu().numpy()
 
     if f"{name}_{tol}" == group:
         # there might be a third dimension (eg isobaricInhPa) : basis for nanmask duplication

--- a/py4cast/io/outputs.py
+++ b/py4cast/io/outputs.py
@@ -182,7 +182,12 @@ def write_storable_dataset(
     tol = used_grib_feat["typeOfLevel"].drop_duplicates().tolist()[0]
     feature_idx = torch.tensor([pred.feature_names_to_idx[f] for f in feature_names])
 
-    data = raw_data.index_select_tensor_dim("features", feature_idx).squeeze().cpu().numpy()
+    data = (
+        raw_data.index_select_tensor_dim("features", feature_idx)
+        .squeeze()
+        .cpu()
+        .numpy()
+    )
 
     if f"{name}_{tol}" == group:
         # there might be a third dimension (eg isobaricInhPa) : basis for nanmask duplication

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -628,7 +628,7 @@ class AutoRegressiveLightning(LightningModule):
 
         If downscaling strategy, the previous_states are set to 0.
         """
-        forcing = batch.forcing.select_dim("timestep", step_idx, bare_tensor=False)
+        forcing = batch.forcing.select_dim("timestep", step_idx)
         ds = self.training_strategy == "downscaling_only"
         inputs = [
             prev_states.select_dim("timestep", idx) * (1 - ds)

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -631,7 +631,7 @@ class AutoRegressiveLightning(LightningModule):
         forcing = batch.forcing.select_dim("timestep", step_idx)
         ds = self.training_strategy == "downscaling_only"
         inputs = [
-            prev_states.select_dim("timestep", idx) * (1 - ds)
+            prev_states.select_tensor_dim("timestep", idx) * (1 - ds)
             for idx in range(batch.num_input_steps)
         ]
         x = torch.cat(

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -488,7 +488,7 @@ class AutoRegressiveLightning(LightningModule):
         # for the desired number of ar steps.
         for i in range(batch.num_pred_steps):
             if not (phase == "inference"):
-                border_state = batch.outputs.select_dim("timestep", i)
+                border_state = batch.outputs.select_tensor_dim("timestep", i)
 
             if scale_y:
                 step_diff_std, step_diff_mean = self._step_diffs(
@@ -521,14 +521,14 @@ class AutoRegressiveLightning(LightningModule):
                 if scale_y:
                     predicted_state = (
                         # select the last timestep
-                        prev_states.select_dim("timestep", -1)
+                        prev_states.select_tensor_dim("timestep", -1)
                         + y * step_diff_std
                         + step_diff_mean
                     )
                 else:
                     ds = self.training_strategy == "downscaling_only"
                     predicted_state = (
-                        prev_states.select_dim("timestep", -1) * (1 - ds) + y
+                        prev_states.select_tensor_dim("timestep", -1) * (1 - ds) + y
                     )
 
                 # Overwrite border with true state

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -548,7 +548,7 @@ class AutoRegressiveLightning(LightningModule):
                     new_prev_states_tensor = torch.cat(
                         [
                             # Drop the oldest timestep (select all but the first)
-                            prev_states.index_select_dim(
+                            prev_states.index_select_tensor_dim(
                                 "timestep",
                                 range(1, prev_states.dim_size("timestep")),
                             ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ transformers==4.45.2
 torch-geometric==2.6.1
 tornado==6.4.1
 mlflow==2.17.2
-mfai @ git+https://github.com/meteofrance/mfai@330e37e
+mfai @ git+https://github.com/meteofrance/mfai@e6fccce
 scikit-image==0.24.0
 lightning-bolts==0.7.0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -336,7 +336,7 @@ def test_write_template_dataset():
     )
 
     pred.tensor[0, :, 1] = torch.tensor(6.28320000, dtype=torch.float32)
-    raw_data = pred.select_dim("timestep", 0, bare_tensor=False)
+    raw_data = pred.select_dim("timestep", 0)
 
     receiver_ds = out.write_storable_dataset(
         pred,
@@ -403,7 +403,7 @@ def test_write_template_dataset():
     )
 
     pred.tensor[0, :, 1] = torch.tensor(6.28320000, dtype=torch.float32)
-    raw_data = pred.select_dim("timestep", 0, bare_tensor=False)
+    raw_data = pred.select_dim("timestep", 0)
 
     receiver_ds = out.write_storable_dataset(
         pred,
@@ -469,7 +469,7 @@ def test_write_template_dataset():
     )
 
     pred.tensor[0, :, 0] = torch.tensor(3.1416, dtype=torch.float32)
-    raw_data = pred.select_dim("timestep", 0, bare_tensor=False)
+    raw_data = pred.select_dim("timestep", 0)
 
     receiver_ds = out.write_storable_dataset(
         pred,
@@ -531,7 +531,7 @@ def test_write_template_dataset():
         feature_names=["u10_10"],
     )
 
-    raw_data = pred.select_dim("timestep", 0, bare_tensor=False)
+    raw_data = pred.select_dim("timestep", 0)
 
     dummy_template = FakeHaGDs(lat[::-1], lon, levels[0], {"u10_10": "u10"})
 


### PR DESCRIPTION
See [mfai PR#49](https://github.com/meteofrance/mfai/pull/49) for a detailed description of the NamedTensor changes.

Broadly, methods that had the `bare_tensor` parameter, wich governed wether the return type was `NamedTensor` or `torch.Tensor` have been split into 2 methods. One for each return type.
```python
    def select_dim(self, dim_name: str, index: int, bare_tensor: bool = True) -> Union["NamedTensor", torch.Tensor]:
```
becomes
```python
    def select_dim(self, dim_name: str) -> "NamedTensor":

    def select_tensor_dim(self, dim_name: str) -> torch.Tensor:
 ```