### PR TITLE
Remove inputs in dowscaling strategy

### DIFF
--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -636,18 +636,10 @@ class AutoRegressiveLightning(LightningModule):
             for idx in range(batch.num_input_steps)
         ]
         x = torch.cat(
-            inputs * (1 - ds) + [self.grid_static_features[: batch.batch_size], forcing.tensor],
+            inputs * (1 - ds)
+            + [self.grid_static_features[: batch.batch_size], forcing.tensor],
             dim=forcing.dim_index("features"),
         )
-
-        import matplotlib.pyplot as plt
-        plt.figure(figsize=(18, 6))
-        for i in range(x.shape[-1]):
-            plt.subplot(5, 5, i + 1)
-            plt.imshow(x[0, :, :, i].detach().cpu().numpy())
-            plt.title(f"x {i}")
-        plt.tight_layout()
-        plt.savefig("test_x.png")
 
         return x
 


### PR DESCRIPTION
Remove inputs (which were set to zeros) from the concatenation between forcings and statistics in _next_x of the lightning in the case of a downsalling only strategy.