### PR TITLE
Training reproducibility

### DIFF
--- a/config/CLI/dataset/titan.yaml
+++ b/config/CLI/dataset/titan.yaml
@@ -1,6 +1,6 @@
 data:
   #args forwarded (linked) to model
-  dataset_name: titan_full
+  dataset_name: titan_aro_arp
   num_input_steps: 1
   num_pred_steps_train: 1
   num_pred_steps_val_test: 1

--- a/config/CLI/dataset/titan.yaml
+++ b/config/CLI/dataset/titan.yaml
@@ -1,6 +1,6 @@
 data:
   #args forwarded (linked) to model
-  dataset_name: titan_aro_arp
+  dataset_name: titan_full
   num_input_steps: 1
   num_pred_steps_train: 1
   num_pred_steps_val_test: 1
@@ -19,11 +19,13 @@ data:
       valid:
         start: 20230101
         end: 20231231
-        obs_step: 10800
+        obs_step: 3600
+        obs_step_btw_t0: 10800
       test:
         start: 20240101
         end: 20240831
-        obs_step: 10800
+        obs_step: 3600
+        obs_step_btw_t0: 10800
     grid:
       name: PAAROME_1S40
       border_size: 0

--- a/config/CLI/model/customunet.yaml
+++ b/config/CLI/model/customunet.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     encoder_name: resnet18
     encoder_depth: 5

--- a/config/CLI/model/deeplabv3.yaml
+++ b/config/CLI/model/deeplabv3.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     encoder_name: resnet18
     encoder_depth: 5

--- a/config/CLI/model/deeplabv3plus.yaml
+++ b/config/CLI/model/deeplabv3plus.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     encoder_name: resnet18
     encoder_depth: 5

--- a/config/CLI/model/graphlam.yaml
+++ b/config/CLI/model/graphlam.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     tmp_dir: /tmp  # nosec B108
     hidden_dims: 64

--- a/config/CLI/model/halfunet.yaml
+++ b/config/CLI/model/halfunet.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     num_filters: 64
     dilation: 1

--- a/config/CLI/model/hilam.yaml
+++ b/config/CLI/model/hilam.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     tmp_dir: /tmp  # nosec B108
     hidden_dims: 64

--- a/config/CLI/model/hilamparallel.yaml
+++ b/config/CLI/model/hilamparallel.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     tmp_dir: /tmp  # nosec B108
     hidden_dims: 64

--- a/config/CLI/model/segformer.yaml
+++ b/config/CLI/model/segformer.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     # dims: (32, 64, 160, 256) # Unsupported type by yaml
     # heads: (1, 2, 5, 8)

--- a/config/CLI/model/swinunetr.yaml
+++ b/config/CLI/model/swinunetr.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     depths: [2, 2, 2, 2]
     num_heads: [3, 6, 12, 24]

--- a/config/CLI/model/unet.yaml
+++ b/config/CLI/model/unet.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     init_features: 64
     autopad_enabled: True

--- a/config/CLI/model/unetrpp.yaml
+++ b/config/CLI/model/unetrpp.yaml
@@ -7,6 +7,10 @@ model:
   channels_last: False # True: B W H C
   io_conf : null
   mask_ratio : 0 # 0<mask_ratio<1. If !=0 apply maskedautoencoderstrategy.
+  learning_rate: 1e-3
+  min_learning_rate: 3e-7
+  num_warmup_steps: 1000
+  betas: [0.9, 0.95]
   settings_init_args:
     hidden_size: 1024
     num_heads_encoder: 16

--- a/config/CLI/trainer.yaml
+++ b/config/CLI/trainer.yaml
@@ -3,19 +3,6 @@ seed_everything: true
 
 ckpt_path: #EMPTY: runs as usual. NOT EMPTY: load weights and hyperparameters from checkpoint
 
-optimizer:
-  class_path: torch.optim.AdamW
-  init_args:
-    lr: 0.001
-
-lr_scheduler:
-  class_path: pl_bolts.optimizers.lr_scheduler.LinearWarmupCosineAnnealingLR
-  init_args:
-    warmup_epochs: 1
-    max_epochs: 500
-    eta_min: 0
-
-
 trainer:               # Native training arguments of ligthining.pytorch.Trainer
 
   fast_dev_run: False  # True: fit with only 1 batch and 1 epoch, use for dev (logging & checkpointing disabled)
@@ -66,6 +53,7 @@ trainer:               # Native training arguments of ligthining.pytorch.Trainer
         mode: min
         patience: 50
 
+  num_sanity_val_steps: 0
   log_every_n_steps: 50        # Num of batches btw logging
   accumulate_grad_batches: 10  # Num of batches before optim step
   deterministic: False         # True for reproducibility but increases computation time

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -413,7 +413,7 @@ class AutoRegressiveLightning(LightningModule):
     def on_fit_start(self):
         self.log_hparams_tb()
         self.print_summary_model()
-    
+
     def configure_optimizers(self):
         """
         Configure the optimizer and scheduler


### PR DESCRIPTION
This PR aims at finding the configuration to reproduce early acceptable experiments. It adresses issue #159.

What changed in this PR:

* added the keyword `obs_step_btw_t0` in order to subsample the validation/test period,
* changed the learning rate scheduler to reuse the former one (from Hugging Face's `transformers`).

Be carefull as now the learning rate and others parameters for the optimizer are in the model config file.