### PR TITLE
Allowing the use of `load_from_checkpoint` outside the scope of LightningCLI

### DIFF
--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -294,6 +294,7 @@ class AutoRegressiveLightning(LightningModule):
 
     def setup(self, stage=None):
         if self.logging_enabled:
+            self.logger.log_hyperparams(self.hparams)
             self.save_path = Path(self.trainer.log_dir)
             max_pred_step = self.num_pred_steps_val_test - 1
             self.rmse_psd_plot_metric = MetricPSDVar(pred_step=max_pred_step)

--- a/py4cast/lightning.py
+++ b/py4cast/lightning.py
@@ -202,6 +202,8 @@ class AutoRegressiveLightning(LightningModule):
             )
 
         self.save_hyperparameters()  # write hparams.yaml in save folder
+        self.hparams["dataset_info"] = dataset_info
+        self.hparams["infer_ds"] = infer_ds
 
         # Load static features for grid/data
         # We do not want to change dataset statics inplace


### PR DESCRIPTION
This PR fixes a known limitation of the LightningCLI, hyperparameters and checkpointing.

Lightning saves the init args from the `LightningModule`'s constructor into the checkpoint under `hyper_parameters`. But when one uses `link_arguments(..., apply_on="instantiate")`, the linked arguments are injected **_after_** instantiation. That means that `save_hyperparameters()` does not see these arguments.

One solution is to manually add the linked arguments to the hyperparameters.

This PR fixes issue #157 .

Update: missing arguments are now stored in the `hparams.yaml` file in addition to being saved in the checkpoint.