### PR TITLE
Empty tensor in plots

### DIFF
--- a/py4cast/plots.py
+++ b/py4cast/plots.py
@@ -299,9 +299,11 @@ class MapPlot(Plotter):
             prediction_rescaled = pred * std + mean
             target_rescaled = targ * std + mean
             batch_copy.inputs.tensor = batch_copy.inputs.tensor * std + mean
-            batch_copy.forcing.tensor[:, :, :, :, :-5] = (
-                batch_copy.forcing.tensor[:, :, :, :, :-5] * std + mean
-            )  # not rescalled cos_hour, ect
+            # rescale other forcing variables except cos_hour etc
+            if batch_copy.forcing.tensor.shape[-1] > 5:
+                batch_copy.forcing.tensor[:, :, :, :, :-5] = (
+                    batch_copy.forcing.tensor[:, :, :, :, :-5] * std + mean
+                )
 
             # Iterate over the examples
             # We assume examples are already on grid


### PR DESCRIPTION
Bug correction.

If there is no arpege data in inputs, forcing variables are limited to 5.
In this case the slice tensor[:, :, :, :, :-5] returns None and therefore an error later in the code.

I have just add a condition to enter in this case